### PR TITLE
BugFix from Pinguem.ru competition

### DIFF
--- a/Other/libs/ColorQuantizer/SimplePaletteQuantizer/Quantizers/Popularity/PopularityQuantizer.cs
+++ b/Other/libs/ColorQuantizer/SimplePaletteQuantizer/Quantizers/Popularity/PopularityQuantizer.cs
@@ -97,7 +97,7 @@ namespace SimplePaletteQuantizer.Quantizers.Popularity
             // the average color from them, thus our new palette.
             IEnumerable<Color> colors = colorMap.
                  OrderBy(entry => random.Next(colorMap.Count)).
-                 OrderByDescending(entry => entry.Value.PixelCount).
+                 ThenByDescending(entry => entry.Value.PixelCount).
                  Take(colorCount).
                  Select(entry => entry.Value.GetAverage());
 

--- a/TSOClient/FSO.IDE/ObjectWindow.cs
+++ b/TSOClient/FSO.IDE/ObjectWindow.cs
@@ -51,7 +51,7 @@ namespace FSO.IDE
 
             if (entries.Count == 0) return false;
 
-            entries = entries.OrderBy(x => x.SubIndex).OrderBy(x => x.Group).ToList();
+            entries = entries.OrderBy(x => x.SubIndex).ThenBy(x => x.Group).ToList();
 
             var GUID = (ActiveObj == null) ? 0 : ActiveObj.OBJ.GUID;
             //populate object selected box with options

--- a/TSOClient/tso.client/Controllers/MessagingController.cs
+++ b/TSOClient/tso.client/Controllers/MessagingController.cs
@@ -142,7 +142,7 @@ namespace FSO.Client.Controllers
                         message.Message = GameFacade.Strings.GetString("195", "18");
                         break;
                     default:
-                        message.Message = message.Message = GameFacade.Strings.GetString("195", "11");
+                        message.Message = GameFacade.Strings.GetString("195", "11");
                         break;
                 }
             }

--- a/TSOClient/tso.client/UI/Panels/EODs/UIPizzaMakerEOD.cs
+++ b/TSOClient/tso.client/UI/Panels/EODs/UIPizzaMakerEOD.cs
@@ -187,7 +187,7 @@ namespace FSO.Client.UI.Panels.EODs
             int resultVal = 1;
             int.TryParse(txt, out resultVal);
             if (resultVal > 1 && resultVal < 5) SetTip(Script.GetString("strResultSuccess"));
-            else if (resultVal > 4 && resultVal < 8) SetTip(Script.GetString("strResultSuccessBonus"));
+            else if (resultVal > 5 && resultVal < 8) SetTip(Script.GetString("strResultSuccessBonus"));
             else SetTip(Script.GetString("strResultFailure"));
         }
 

--- a/TSOClient/tso.content/model/CityMap.cs
+++ b/TSOClient/tso.content/model/CityMap.cs
@@ -113,10 +113,10 @@ namespace FSO.Content.Model
             t = GetTerrain(x-1, y + 1);
             if ((y + 1 < 512) && (x - 1 >= 0) && (t > sample)) edges[5] = t;
 
-            t = t = GetTerrain(x-1, y);
+            t = GetTerrain(x-1, y);
             if ((x - 1 >= 0) && (t > sample)) edges[6] = t;
 
-            t = t = GetTerrain(x - 1, y - 1);
+            t =  GetTerrain(x - 1, y - 1);
             if ((y - 1 >= 0) && (x - 1 >= 0) && (t > sample)) edges[7] = t;
 
             int binary = 0;

--- a/TSOClient/tso.files/HIT/EVT.cs
+++ b/TSOClient/tso.files/HIT/EVT.cs
@@ -75,8 +75,8 @@ namespace FSO.Files.HIT
                 IsHex = true;
             }
             //Sigh, Maxis...
-            else if (input.Contains("a") || input.Contains("b") || input.Contains("b") ||
-                input.Contains("c") || input.Contains("d") || input.Contains("e") || input.Contains("f"))
+            else if (input.Contains("a") || input.Contains("b") || input.Contains("c") ||
+                     input.Contains("d") || input.Contains("e") || input.Contains("f"))
             {
                 IsHex = true;
             }

--- a/TSOClient/tso.files/HIT/Track.cs
+++ b/TSOClient/tso.files/HIT/Track.cs
@@ -92,8 +92,8 @@ namespace FSO.Files.HIT
                 IsHex = true;
             }
             //Sigh, Maxis...
-            else if (input.Contains("a") || input.Contains("b") || input.Contains("b") ||
-                input.Contains("c") || input.Contains("d") || input.Contains("e") || input.Contains("f"))
+            else if (input.Contains("a") || input.Contains("b") || input.Contains("c") ||
+                     input.Contains("d") || input.Contains("e") || input.Contains("f"))
             {
                 IsHex = true;
             }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bugs, found using PVS-Studio:

### V3092 

- V3092 Range intersections are possible within conditional expressions. Example: if (A > 0 && A < 5) { ... } else if (A > 3 && A < 9) { ... }. FSO.Client UIPizzaMakerEOD.cs 189

### V3078 

- V3078 Original sorting order will be lost after repetitive call to 'OrderBy' method. Use 'ThenBy' method to preserve the original sorting. FSO.IDE ObjectWindow.cs 54

- V3078 Original sorting order will be lost after repetitive call to 'OrderByDescending' method. Use 'ThenByDescending' method to preserve the original sorting. SimplePaletteQuantizer PopularityQuantizer.cs 100

### V3005 

- V3005 The 'message.Message' variable is assigned to itself. FSO.Client MessagingController.cs 145

- V3005 The 't' variable is assigned to itself. FSO.Content CityMap.cs 116

- V3005 The 't' variable is assigned to itself. FSO.Content CityMap.cs 119

### V3001 

- V3001 There are identical sub-expressions 'input.Contains("b")' to the left and to the right of the '||' operator. FSO.Files EVT.cs 78

- V3001 There are identical sub-expressions 'input.Contains("b")' to the left and to the right of the '||' operator. FSO.Files Track.cs 95