### PR TITLE
Basic shortcut key functionality. Minor chatbox changes

### DIFF
--- a/TSOClient/tso.client/UI/Panels/UIChatPanel.cs
+++ b/TSOClient/tso.client/UI/Panels/UIChatPanel.cs
@@ -78,6 +78,7 @@ namespace FSO.Client.UI.Panels
                     HistoryDialog.Visible = !HistoryDialog.Visible;
                 };
                 Add(btn);
+                
             }
 
             Style = TextStyle.DefaultTitle.Clone();
@@ -177,10 +178,10 @@ namespace FSO.Client.UI.Panels
             botRect.Y = GlobalSettings.Default.GraphicsHeight - ((Owner.PanelActive) ? 135 : 20);
 
             InvalidAreas[3] = botRect;
+            var lastFocus = state.InputManager.GetFocus();
             if (HistoryDialog.Visible) TextBox.Visible = false;
             else
             {
-                var lastFocus = state.InputManager.GetFocus();
                 if (state.NewKeys.Contains(Keys.Enter) && (Owner.EODs.ActiveEOD == null ||
                         lastFocus == null || lastFocus == TextBox ||
                         lastFocus == HistoryDialog.ChatEntryTextEdit
@@ -193,11 +194,35 @@ namespace FSO.Client.UI.Panels
                     if (TextBox.Visible) state.InputManager.SetFocus(TextBox);
                 }
             }
-
+            if (state.NewKeys.Contains(Keys.Escape))
+            {
+                if (TextBox.Visible)
+                {
+                    TextBox.Clear();
+                    TextBox.Visible = !TextBox.Visible;
+                }
+                if (HistoryDialog.Visible)
+                    if (HistoryDialog.ChatEntryTextEdit.CurrentText.Length > 0)
+                    {
+                        HistoryDialog.ChatEntryTextEdit.CurrentText = "";
+                        HistoryDialog.OKButton.Disabled = true;
+                    }
+                    else if (lastFocus == HistoryDialog.ChatEntryTextEdit)
+                        state.InputManager.SetFocus(null);
+            }
+            if (state.NewKeys.Contains(Keys.Enter) && HistoryDialog.Visible)
+            {
+                if (HistoryDialog.ChatEntryTextEdit.CurrentText.Length < 1)
+                    if (lastFocus == HistoryDialog.ChatEntryTextEdit)
+                        state.InputManager.SetFocus(null);
+                    else
+                        state.InputManager.SetFocus(HistoryDialog.ChatEntryTextEdit);
+            }
             if (state.NewKeys.Contains(Keys.H) && state.CtrlDown)
             {
-                state.InputManager.SetFocus(null);
                 HistoryDialog.Visible = !HistoryDialog.Visible;
+                if (HistoryDialog.Visible) state.InputManager.SetFocus(HistoryDialog.ChatEntryTextEdit);
+                else state.InputManager.SetFocus(null);
             }
 
             if (state.NewKeys.Contains(Keys.OemPlus) && state.CtrlDown && HistoryDialog.Visible) {

--- a/TSOClient/tso.client/UI/Panels/UIChatPanel.cs
+++ b/TSOClient/tso.client/UI/Panels/UIChatPanel.cs
@@ -179,7 +179,6 @@ namespace FSO.Client.UI.Panels
 
             InvalidAreas[3] = botRect;
             var lastFocus = state.InputManager.GetFocus();
-            if (lastFocus != null && !TextBox.Visible && !HistoryDialog.Visible) state.InputManager.SetFocus(null); // Reset focus to null if chat boxes aren't open
             if (HistoryDialog.Visible) TextBox.Visible = false;
             else
             {

--- a/TSOClient/tso.client/UI/Panels/UIChatPanel.cs
+++ b/TSOClient/tso.client/UI/Panels/UIChatPanel.cs
@@ -179,6 +179,7 @@ namespace FSO.Client.UI.Panels
 
             InvalidAreas[3] = botRect;
             var lastFocus = state.InputManager.GetFocus();
+            if (lastFocus != null && !TextBox.Visible && !HistoryDialog.Visible) state.InputManager.SetFocus(null); // Reset focus to null if chat boxes aren't open
             if (HistoryDialog.Visible) TextBox.Visible = false;
             else
             {
@@ -215,7 +216,7 @@ namespace FSO.Client.UI.Panels
                 if (HistoryDialog.ChatEntryTextEdit.CurrentText.Length < 1)
                     if (lastFocus == HistoryDialog.ChatEntryTextEdit)
                         state.InputManager.SetFocus(null);
-                    else
+                    else if (lastFocus == null)
                         state.InputManager.SetFocus(HistoryDialog.ChatEntryTextEdit);
             }
             if (state.NewKeys.Contains(Keys.H) && state.CtrlDown)

--- a/TSOClient/tso.client/UI/Panels/UILotControl.cs
+++ b/TSOClient/tso.client/UI/Panels/UILotControl.cs
@@ -87,6 +87,8 @@ namespace FSO.Client.UI.Panels
         private int OldMY;
         private bool FoundMe; //if false and avatar changes, center. Should center on join lot.
 
+        public bool KBScroll;
+
         public bool RMBScroll;
         private int RMBScrollX;
         private int RMBScrollY;
@@ -731,6 +733,20 @@ namespace FSO.Client.UI.Panels
                 if (ShowTooltip) state.UIState.TooltipProperties.UpdateDead = false;
 
                 bool scrolled = false;
+                if (KBScroll)
+                {
+                    World.State.ScrollAnchor = null;
+                    int KeyboardAxisX = 0;
+                    int KeyboardAxisY = 0;
+                    Vector2 scrollBy = new Vector2();
+                    if (state.KeyboardState.IsKeyDown(Keys.Up) || state.KeyboardState.IsKeyDown(Keys.W)) KeyboardAxisY -= 1;
+                    if (state.KeyboardState.IsKeyDown(Keys.Left) || state.KeyboardState.IsKeyDown(Keys.A)) KeyboardAxisX -= 1;
+                    if (state.KeyboardState.IsKeyDown(Keys.Down) || state.KeyboardState.IsKeyDown(Keys.S)) KeyboardAxisY += 1;
+                    if (state.KeyboardState.IsKeyDown(Keys.Right) || state.KeyboardState.IsKeyDown(Keys.D)) KeyboardAxisX += 1;
+                    scrollBy = new Vector2(KeyboardAxisX, KeyboardAxisY);
+                    scrollBy *= 0.05f;
+                    World.Scroll(scrollBy * (60f / FSOEnvironment.RefreshRate));
+                }
                 if (RMBScroll)
                 {
                     World.State.ScrollAnchor = null;
@@ -768,7 +784,13 @@ namespace FSO.Client.UI.Panels
                     World.Scroll(scrollBy * (60f / FSOEnvironment.RefreshRate));
                     scrolled = true;
                 }
-                if (MouseIsOn)
+                var lastFocus = state.InputManager.GetFocus();
+                if (state.KeyboardState.IsKeyDown(Keys.Up) || state.KeyboardState.IsKeyDown(Keys.Left) || state.KeyboardState.IsKeyDown(Keys.Down) || state.KeyboardState.IsKeyDown(Keys.Right) ||
+                    (lastFocus == null && (state.KeyboardState.IsKeyDown(Keys.W) || state.KeyboardState.IsKeyDown(Keys.A) || state.KeyboardState.IsKeyDown(Keys.S) || state.KeyboardState.IsKeyDown(Keys.D))))
+                    KBScroll = true;
+                else
+                    KBScroll = false;
+                    if (MouseIsOn)
                 {
                     if (state.MouseState.RightButton == ButtonState.Pressed)
                     {

--- a/TSOClient/tso.client/UI/Screens/CoreGameScreen.cs
+++ b/TSOClient/tso.client/UI/Screens/CoreGameScreen.cs
@@ -358,7 +358,7 @@ namespace FSO.Client.UI.Screens
 
             base.Update(state);
 
-            if (state.NewKeys.Contains(Microsoft.Xna.Framework.Input.Keys.F1))
+            if (state.NewKeys.Contains(Microsoft.Xna.Framework.Input.Keys.F1) && state.CtrlDown)
                 FSOFacade.Controller.ToggleDebugMenu();
 
             if (CityRenderer != null)


### PR DESCRIPTION
- Shortcut keys added:
  - F1 - Live Mode
  - F2 - Buy Mode
  - F3 - Build Mode
  - F4 - Property Mode
  - F5 - Options
  - +/- - Zooms view in/out (2D & 3D)
  - </> - Rotates view left/right (2D & 3D)
  - Home/End - Steps walls up/down
  - Page Up/Down - Ascends/descends the active floor
  - WASD/Arrow Keys - Pans the camera (2D & 3D)
  - CTRL+F1 - Toggles the debug menu (This was changed to prevent conflicts with the Live Mode shortcut key)

- Chatbox changes
  - The chatbox will now automatically focus when it is opened.
  - Pressing Enter in the chatbox with an empty message will toggle its focus.
  - Pressing ESC while the chatbox is focused will erase any message being typed.
  - Pressing ESC while the chatbox is focused with an empty message will remove its focus.