### PR TITLE
fix issue #91 exception on login screen using ctrl+delete

### DIFF
--- a/TSOClient/tso.common/rendering/framework/io/InputManager.cs
+++ b/TSOClient/tso.common/rendering/framework/io/InputManager.cs
@@ -75,7 +75,7 @@ namespace FSO.Common.Rendering.Framework.IO
 			result.CapsDown = state.KeyboardState.CapsLock;
 			result.NumLockDown = state.KeyboardState.NumLock;
             result.CtrlDown = PressedKeys.Contains(Keys.LeftControl) || PressedKeys.Contains(Keys.RightControl);
-
+            
             for (int j = 0; j < state.NewKeys.Count + charCount; j++)
             {
                 var key = (j<state.NewKeys.Count)?state.NewKeys[j]:Keys.None;
@@ -101,7 +101,7 @@ namespace FSO.Common.Rendering.Framework.IO
                                 }
                                 while (newEndIndex >= 0)
                                 {
-                                    if (Char.IsWhiteSpace(m_SBuilder[newEndIndex]))
+                                    if (m_SBuilder.Length > newEndIndex && Char.IsWhiteSpace(m_SBuilder[newEndIndex])) // for some reason unknown to me yet, newEndIndex can have value equal to the string length thus creating an error. this is a simple fix until a more elegant solution is found :)
                                     {
                                         /** Keep the whitespace char **/
                                         newEndIndex++;


### PR DESCRIPTION
Added a m_SBuilder.Length > newEndIndex check so there won't be exception when trying to access index of string beyond bounds.


If I have to use my instincts i'd say the root of the problem is:
SelectionStart = Math.Min(m_SBuilder.Length, SelectionStart);
Where SelectionStart can get the value of the string length, I dont know if its intended (maybe add (-1)?), but i'm not sure so im just making a small hotfix where the problem occurred.