### PR TITLE
Fix decimal numbers for different User Culture settings

### DIFF
--- a/TSOClient/tso.common/IniConfig.cs
+++ b/TSOClient/tso.common/IniConfig.cs
@@ -24,10 +24,8 @@ namespace FSO.Common
             {
                 try
                 {
-                    if (prop.PropertyType == typeof(decimal) || prop.PropertyType == typeof(double) || prop.PropertyType == typeof(float))
-                        prop.SetValue(this, Convert.ChangeType(AdjustNumberCulture(value, prop.PropertyType), prop.PropertyType));
-                    else if (prop.PropertyType != typeof(string))
-                        prop.SetValue(this, Convert.ChangeType(value, prop.PropertyType));
+                    if (prop.PropertyType != typeof(string))
+                        prop.SetValue(this, Convert.ChangeType(value, prop.PropertyType, CultureInfo.InvariantCulture));
                     else prop.SetValue(this, value);
                 }
                 catch (Exception) { }
@@ -79,25 +77,11 @@ namespace FSO.Common
                     foreach (var prop in props)
                     {
                         if (prop.Name == "Default" || prop.Name == "DefaultValues") continue;
-                        stream.WriteLine(prop.Name + "=" + prop.GetValue(this).ToString());
+                        stream.WriteLine(prop.Name + "=" + Convert.ToString(prop.GetValue(this), CultureInfo.InvariantCulture));
                     }
                 }
             }
             catch (Exception) { }
-        }
-        // Prevents unintended truncation of non-whole numbers due to different user culture settings for number seperators.
-        private string AdjustNumberCulture(string value, Type type)
-        {
-            string ret;
-            if (type == typeof(decimal))
-                ret = value
-                    .Replace(".", CultureInfo.CurrentCulture.NumberFormat.CurrencyDecimalSeparator)
-                    .Replace(",", CultureInfo.CurrentCulture.NumberFormat.CurrencyDecimalSeparator);
-            else // float or double
-                ret = value
-                    .Replace(".", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator)
-                    .Replace(",", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
-            return ret;
         }
     }
 }

--- a/TSOClient/tso.common/IniConfig.cs
+++ b/TSOClient/tso.common/IniConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -23,7 +24,9 @@ namespace FSO.Common
             {
                 try
                 {
-                    if (prop.PropertyType != typeof(string))
+                    if (prop.PropertyType == typeof(decimal) || prop.PropertyType == typeof(double) || prop.PropertyType == typeof(float))
+                        prop.SetValue(this, Convert.ChangeType(AdjustNumberCulture(value, prop.PropertyType), prop.PropertyType));
+                    else if (prop.PropertyType != typeof(string))
                         prop.SetValue(this, Convert.ChangeType(value, prop.PropertyType));
                     else prop.SetValue(this, value);
                 }
@@ -81,6 +84,20 @@ namespace FSO.Common
                 }
             }
             catch (Exception) { }
+        }
+        // Prevents unintended truncation of non-whole numbers due to different user culture settings for number seperators.
+        private string AdjustNumberCulture(string value, Type type)
+        {
+            string ret;
+            if (type == typeof(decimal))
+                ret = value
+                    .Replace(".", CultureInfo.CurrentCulture.NumberFormat.CurrencyDecimalSeparator)
+                    .Replace(",", CultureInfo.CurrentCulture.NumberFormat.CurrencyDecimalSeparator);
+            else // float or double
+                ret = value
+                    .Replace(".", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator)
+                    .Replace(",", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
+            return ret;
         }
     }
 }


### PR DESCRIPTION
Fixes the issue with default config values that contain decimals (floats, decimals, doubles). It should also update accordingly if a user should ever switch their number separator format.