### PR TITLE
New Jobs UIJobInfo Dialog / Alert

### DIFF
--- a/TSOClient/FSO.UI/Controls/UIProgressBar.cs
+++ b/TSOClient/FSO.UI/Controls/UIProgressBar.cs
@@ -52,8 +52,6 @@ namespace FSO.Client.UI.Controls
             StandardCaptionStyle.Color = new Color(0, 0, 0);
         }
 
-
-
         private float m_Width;
         private float m_Height;
 
@@ -146,8 +144,6 @@ namespace FSO.Client.UI.Controls
             }
         }
 
-
-
         private float m_Value = 0;
         public float Value
         {
@@ -165,12 +161,6 @@ namespace FSO.Client.UI.Controls
             }
         }
 
-
-
-
-
-
-
         public float Width
         {
             get { return m_Width; }
@@ -187,7 +177,6 @@ namespace FSO.Client.UI.Controls
             m_Height = height;
             m_Bounds = new Rectangle(0, 0, (int)width, (int)height);
         }
-
 
         public override void Update(UpdateState state)
         {

--- a/TSOClient/tso.client/FSO.Client.csproj
+++ b/TSOClient/tso.client/FSO.Client.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Rendering\City\Plugins\MapPainterPlugin.cs" />
     <Compile Include="Rendering\City\Plugins\NeighbourhoodEditPlugin.cs" />
     <Compile Include="Rendering\City\TLayerVertex.cs" />
+    <Compile Include="UI\Profile\UIJobInfo.cs" />
     <Compile Include="UI\Controls\UIRatingDisplay.cs" />
     <Compile Include="UI\Controls\UISlotsImage.cs" />
     <Compile Include="UI\Controls\UIAvatarThumbnail.cs" />

--- a/TSOClient/tso.client/FSOFacade.cs
+++ b/TSOClient/tso.client/FSOFacade.cs
@@ -1,6 +1,5 @@
 ﻿using FSO.Client.UI.Hints;
 using FSO.Client.UI.Panels;
-using FSO.Client.UI.Profile;
 using Ninject;
 using System;
 using System.Collections.Generic;

--- a/TSOClient/tso.client/FSOFacade.cs
+++ b/TSOClient/tso.client/FSOFacade.cs
@@ -1,5 +1,6 @@
 ﻿using FSO.Client.UI.Hints;
 using FSO.Client.UI.Panels;
+using FSO.Client.UI.Profile;
 using Ninject;
 using System;
 using System.Collections.Generic;

--- a/TSOClient/tso.client/UI/Panels/UILotControl.cs
+++ b/TSOClient/tso.client/UI/Panels/UILotControl.cs
@@ -46,7 +46,7 @@ using Ninject;
 using FSO.Client.Network;
 using FSO.Client.UI.Panels.Neighborhoods;
 using FSO.UI.Controls;
-using FSO.Client.UI.Profile;
+using FSO.Client.UI.Panels.Profile;
 
 namespace FSO.Client.UI.Panels
 {
@@ -280,11 +280,6 @@ namespace FSO.Client.UI.Panels
             var b2Event = (info.Block) ? new ButtonClickDelegate(DialogButton2) : null;
 
             VMDialogType type = (info.Operand == null) ? VMDialogType.Message : info.Operand.Type;
-
-            if (info.Operand.MessageStringID == 19)
-            {
-                type = VMDialogType.FSOJob;
-            }
 
             switch (type)
             {

--- a/TSOClient/tso.client/UI/Panels/UILotControl.cs
+++ b/TSOClient/tso.client/UI/Panels/UILotControl.cs
@@ -46,6 +46,7 @@ using Ninject;
 using FSO.Client.Network;
 using FSO.Client.UI.Panels.Neighborhoods;
 using FSO.UI.Controls;
+using FSO.Client.UI.Profile;
 
 namespace FSO.Client.UI.Panels
 {
@@ -329,7 +330,16 @@ namespace FSO.Client.UI.Panels
                     break;
                 case VMDialogType.FSOJob:
                     VMAvatar avatar = (VMAvatar)info.Caller;
-                    VMAvatar something = ((info.Caller as VMAvatar));
+
+                    //Find their current active job
+                    VMTSOAvatarState state = (VMTSOAvatarState)avatar.TSOState;
+                    KeyValuePair<short, VMTSOJobInfo> jobInfo = state.JobInfo.FirstOrDefault(x => x.Value.StatusFlags == 1);
+                    if (jobInfo.Key != 0)
+                    {
+                        JobInformation JobInfo = new JobInformation((int)jobInfo.Value.Level, (int)jobInfo.Key, (int)jobInfo.Value.Experience); //Job Grade, Job Type, Experience
+                        var jobInfoAlert = new UIJobInfo(JobInfo);
+                        jobInfoAlert.Show();
+                    }
                     return;
             }
 

--- a/TSOClient/tso.client/UI/Panels/UILotControl.cs
+++ b/TSOClient/tso.client/UI/Panels/UILotControl.cs
@@ -280,6 +280,11 @@ namespace FSO.Client.UI.Panels
 
             VMDialogType type = (info.Operand == null) ? VMDialogType.Message : info.Operand.Type;
 
+            if (info.Operand.MessageStringID == 19)
+            {
+                type = VMDialogType.FSOJob;
+            }
+
             switch (type)
             {
                 default:
@@ -322,6 +327,10 @@ namespace FSO.Client.UI.Panels
                     options.Buttons = new UIAlertButton[] { new UIAlertButton(UIAlertButtonType.OK, b0Event, info.Yes), new UIAlertButton(UIAlertButtonType.Cancel, b1Event, info.Cancel) };
                     options.GenericAddition = new UIColorPicker();
                     break;
+                case VMDialogType.FSOJob:
+                    VMAvatar avatar = (VMAvatar)info.Caller;
+                    VMAvatar something = ((info.Caller as VMAvatar));
+                    return;
             }
 
             var alert = UIScreen.GlobalShowAlert(options, false);

--- a/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
+++ b/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
@@ -703,7 +703,6 @@ namespace FSO.Client.UI.Panels
             {
                 var jobInfoAlert = new UIJobInfo(JobInfo);
                 jobInfoAlert.Show();
-                JobInfo = default(JobInformation);
             } else
             {
                 UIScreen.GlobalShowAlert(new UIAlertOptions()

--- a/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
+++ b/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
@@ -165,6 +165,8 @@ namespace FSO.Client.UI.Panels
         private UIRelationshipsTab _RelationshipsTab = UIRelationshipsTab.Outgoing;
         private string OriginalDescription;
         private string JobAlertText;
+        private JobInformation JobInfo;
+
         private bool LocalDataChange;
 
         private int TotalLocks = 20;
@@ -697,16 +699,8 @@ namespace FSO.Client.UI.Panels
 
         private void ShowJobInfo(UIElement button)
         {
-
-            var jobInfo = new UIJobInfo(JobAlertText);
-            jobInfo.Show();
-
-            UIScreen.GlobalShowAlert(new UIAlertOptions()
-            {
-                Title = GameFacade.Strings.GetString("189", "64"),
-                Message = JobAlertText,
-                Buttons = UIAlertButton.Ok(),
-            }, true);
+            var jobInfo = new UIJobInfo(JobInfo.MaxLevel);
+            jobInfo.Show(JobInfo);
         }
 
         public void TrySaveDescription()
@@ -929,17 +923,27 @@ namespace FSO.Client.UI.Panels
                         break;
                 }
 
+
+                float promotionPercentage = 0;
                 if ( jobMultipler >= 0 && currentJob.JobLevel_JobGrade < 10)
                 {
                     int nextJobGrade = currentJob.JobLevel_JobGrade + 1;
-                    int maxRequiredRounds = jobMultipler * (nextJobGrade * nextJobGrade);
-                    int totalRoundsCompleted = (int)currentJob.JobLevel_JobExperience / jobExperienceFactor;
-                    int totalRoundsTillPromotion = maxRequiredRounds - totalRoundsCompleted;
-                    JobAlertText += "\r\nShifts till next Promotion: " + totalRoundsTillPromotion;
+                    float maxRequiredRounds = jobMultipler * (nextJobGrade * nextJobGrade);
+                    float totalRoundsCompleted = (int)currentJob.JobLevel_JobExperience / jobExperienceFactor;
+                    //int totalRoundsTillPromotion = maxRequiredRounds - totalRoundsCompleted;
+                    promotionPercentage = totalRoundsCompleted / maxRequiredRounds;
                 }
 
-
-                
+                JobInfo = new JobInformation();
+                JobInfo.Title = title;
+                JobInfo.Type = GameFacade.Strings.GetString("189", (67 + currentJob.JobLevel_JobType).ToString());
+                JobInfo.Level = currentJob.JobLevel_JobGrade == 0 ? "Trainee" : "Level " + currentJob.JobLevel_JobGrade;
+                JobInfo.Hours = GameFacade.Strings.GetString("189", (73 + poolTime * 2).ToString());
+                JobInfo.CarpoolHours = "Carpool at " + GameFacade.Strings.GetString("189", (74 + poolTime * 2).ToString());
+                JobInfo.NextPosition = (currentJob.JobLevel_JobGrade == 10) ? GameFacade.Strings.GetString("189", "79") :
+                    GameFacade.Strings.GetString("272", (((currentJob.JobLevel_JobType - 1) * 11) + currentJob.JobLevel_JobGrade + 2).ToString());
+                JobInfo.PromotionPercentage = (int)(promotionPercentage * 100);
+                JobInfo.MaxLevel = (currentJob.JobLevel_JobGrade == 10);
             }
             JobsText.CurrentText = outText.ToString();
             JobsText.SetSize(JobsText.Width, 160);

--- a/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
+++ b/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
@@ -2,7 +2,7 @@
 using FSO.Client.UI.Controls;
 using FSO.Client.UI.Framework;
 using FSO.Client.UI.Screens;
-using FSO.Client.UI.Profile;
+using FSO.Client.UI.Panels.Profile;
 using FSO.Client.Utils;
 using FSO.Common.DataService.Model;
 using FSO.Common.Utils;

--- a/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
+++ b/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
@@ -701,8 +701,8 @@ namespace FSO.Client.UI.Panels
         {
             if (!JobInfo.Equals(default(JobInformation)))
             {
-                var jobInfoAlert = new UIJobInfo(JobInfo.MaxLevel);
-                jobInfoAlert.Show(JobInfo);
+                var jobInfoAlert = new UIJobInfo(JobInfo);
+                jobInfoAlert.Show();
                 JobInfo = default(JobInformation);
             } else
             {
@@ -902,64 +902,7 @@ namespace FSO.Client.UI.Panels
                     }
                 }
 
-                //JobAlertText = GameFacade.Strings.GetString("189", "65", new string[] {
-                //    GameFacade.Strings.GetString("189", (67+currentJob.JobLevel_JobType).ToString()),
-                //    title,
-                //    GameFacade.Strings.GetString("189", (73+poolTime*2).ToString()),
-                //    GameFacade.Strings.GetString("189", (74+poolTime*2).ToString()),
-                //    (currentJob.JobLevel_JobGrade == 10) ? GameFacade.Strings.GetString("189", "79") :
-                //    GameFacade.Strings.GetString("272", (((currentJob.JobLevel_JobType - 1) * 11) + currentJob.JobLevel_JobGrade + 2).ToString())
-                //});
-
-                int poolTime = Math.Min(2, currentJob.JobLevel_JobType - 1);
-                int jobMultipler = -1;
-                int jobExperienceFactor = 1;
-                switch (currentJob.JobLevel_JobType - 1)
-                {
-                    case 0: // Robot Factory
-                        jobMultipler = 5;
-                        jobExperienceFactor = 2;
-                        break;
-                    case 1: // Restaurant
-                        jobMultipler = 5;
-                        jobExperienceFactor = 2;
-                        break;
-                    case 2: // Nightclub
-                        jobMultipler = 10;
-                        jobExperienceFactor = 1;
-                        break;
-                    case 4: // Nightclub - Dancer
-                        jobMultipler = 10;
-                        jobExperienceFactor = 1;
-                        break;
-                    default: // Other
-                        jobMultipler = -1;
-                        break;
-                }
-
-
-                float promotionPercentage = 0;
-                if ( jobMultipler >= 0 && currentJob.JobLevel_JobGrade < 10)
-                {
-                    int nextJobGrade = currentJob.JobLevel_JobGrade + 1;
-                    float currentRequiredRounds = jobMultipler * (currentJob.JobLevel_JobGrade * currentJob.JobLevel_JobGrade); //jobMultipler * nextJobGrade^2
-                    float maxRequiredRounds = jobMultipler * (nextJobGrade * nextJobGrade); //jobMultipler * nextJobGrade^2
-                    float totalRoundsCompleted = (int)currentJob.JobLevel_JobExperience / jobExperienceFactor;
-                    float totalRoundsTillPromotion = maxRequiredRounds - totalRoundsCompleted;
-                    float currentRoundsTotal = maxRequiredRounds - currentRequiredRounds;
-                    promotionPercentage = (currentRoundsTotal - totalRoundsTillPromotion) / currentRoundsTotal;
-                }
-
-                JobInfo = new JobInformation();
-                JobInfo.Title = title;
-                JobInfo.Type = GameFacade.Strings.GetString("189", (67 + currentJob.JobLevel_JobType).ToString());
-                JobInfo.Level = currentJob.JobLevel_JobGrade == 0 ? "Trainee" : "Level " + currentJob.JobLevel_JobGrade;
-                JobInfo.Hours = GameFacade.Strings.GetString("189", (73 + poolTime * 2).ToString());
-                JobInfo.CarpoolHours = "Carpool at " + GameFacade.Strings.GetString("189", (74 + poolTime * 2).ToString());
-                JobInfo.NextPosition = (currentJob.JobLevel_JobGrade == 10) ? GameFacade.Strings.GetString("189", "79") :
-                    GameFacade.Strings.GetString("272", (((currentJob.JobLevel_JobType - 1) * 11) + currentJob.JobLevel_JobGrade + 2).ToString());
-                JobInfo.PromotionPercentage = (int)(promotionPercentage * 100);
-                JobInfo.MaxLevel = (currentJob.JobLevel_JobGrade == 10);
+                JobInfo = new JobInformation(currentJob.JobLevel_JobGrade, currentJob.JobLevel_JobType, (int)currentJob.JobLevel_JobExperience);
             }
             JobsText.CurrentText = outText.ToString();
             JobsText.SetSize(JobsText.Width, 160);

--- a/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
+++ b/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
@@ -898,6 +898,43 @@ namespace FSO.Client.UI.Panels
                     (currentJob.JobLevel_JobGrade == 10) ? GameFacade.Strings.GetString("189", "79") :
                     GameFacade.Strings.GetString("272", (((currentJob.JobLevel_JobType - 1) * 11) + currentJob.JobLevel_JobGrade + 2).ToString())
                 });
+
+                int jobMultipler = -1;
+                int jobExperienceFactor = 1;
+                switch (currentJob.JobLevel_JobType - 1)
+                {
+                    case 0: // Robot Factory
+                        jobMultipler = 5;
+                        jobExperienceFactor = 2;
+                        break;
+                    case 1: // Restaurant
+                        jobMultipler = 5;
+                        jobExperienceFactor = 2;
+                        break;
+                    case 2: // Nightclub
+                        jobMultipler = 10;
+                        jobExperienceFactor = 1;
+                        break;
+                    case 4: // Nightclub - Dancer
+                        jobMultipler = 10;
+                        jobExperienceFactor = 1;
+                        break;
+                    default: // Other
+                        jobMultipler = -1;
+                        break;
+                }
+
+                if ( jobMultipler >= 0 && currentJob.JobLevel_JobGrade < 10)
+                {
+                    int nextJobGrade = currentJob.JobLevel_JobGrade + 1;
+                    int maxRequiredRounds = jobMultipler * (nextJobGrade * nextJobGrade);
+                    int totalRoundsCompleted = (int)currentJob.JobLevel_JobExperience / jobExperienceFactor;
+                    int totalRoundsTillPromotion = maxRequiredRounds - totalRoundsCompleted;
+                    JobAlertText += "\r\nShifts till next Promotion: " + totalRoundsTillPromotion;
+                }
+
+
+                
             }
             JobsText.CurrentText = outText.ToString();
             JobsText.SetSize(JobsText.Width, 160);

--- a/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
+++ b/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
@@ -699,8 +699,20 @@ namespace FSO.Client.UI.Panels
 
         private void ShowJobInfo(UIElement button)
         {
-            var jobInfo = new UIJobInfo(JobInfo.MaxLevel);
-            jobInfo.Show(JobInfo);
+            if (!JobInfo.Equals(default(JobInformation)))
+            {
+                var jobInfoAlert = new UIJobInfo(JobInfo.MaxLevel);
+                jobInfoAlert.Show(JobInfo);
+                JobInfo = default(JobInformation);
+            } else
+            {
+                UIScreen.GlobalShowAlert(new UIAlertOptions()
+                {
+                    Title = GameFacade.Strings.GetString("189", "64"),
+                    Message = JobAlertText,
+                    Buttons = UIAlertButton.Ok(),
+                }, true);
+            }
         }
 
         public void TrySaveDescription()
@@ -871,6 +883,7 @@ namespace FSO.Client.UI.Panels
             {
                 outText.Append(GameFacade.Strings.GetString("189", "61") + "\r\n\r\n"); //unemployed
                 JobAlertText = GameFacade.Strings.GetString("189", "66");
+                JobInfo = default(JobInformation);
             }
             else
             {
@@ -888,16 +901,17 @@ namespace FSO.Client.UI.Panels
                         outText.Append("\r\n");
                     }
                 }
-                int poolTime = Math.Min(2, currentJob.JobLevel_JobType - 1);
-                JobAlertText = GameFacade.Strings.GetString("189", "65", new string[] {
-                    GameFacade.Strings.GetString("189", (67+currentJob.JobLevel_JobType).ToString()),
-                    title,
-                    GameFacade.Strings.GetString("189", (73+poolTime*2).ToString()),
-                    GameFacade.Strings.GetString("189", (74+poolTime*2).ToString()),
-                    (currentJob.JobLevel_JobGrade == 10) ? GameFacade.Strings.GetString("189", "79") :
-                    GameFacade.Strings.GetString("272", (((currentJob.JobLevel_JobType - 1) * 11) + currentJob.JobLevel_JobGrade + 2).ToString())
-                });
 
+                //JobAlertText = GameFacade.Strings.GetString("189", "65", new string[] {
+                //    GameFacade.Strings.GetString("189", (67+currentJob.JobLevel_JobType).ToString()),
+                //    title,
+                //    GameFacade.Strings.GetString("189", (73+poolTime*2).ToString()),
+                //    GameFacade.Strings.GetString("189", (74+poolTime*2).ToString()),
+                //    (currentJob.JobLevel_JobGrade == 10) ? GameFacade.Strings.GetString("189", "79") :
+                //    GameFacade.Strings.GetString("272", (((currentJob.JobLevel_JobType - 1) * 11) + currentJob.JobLevel_JobGrade + 2).ToString())
+                //});
+
+                int poolTime = Math.Min(2, currentJob.JobLevel_JobType - 1);
                 int jobMultipler = -1;
                 int jobExperienceFactor = 1;
                 switch (currentJob.JobLevel_JobType - 1)
@@ -928,10 +942,12 @@ namespace FSO.Client.UI.Panels
                 if ( jobMultipler >= 0 && currentJob.JobLevel_JobGrade < 10)
                 {
                     int nextJobGrade = currentJob.JobLevel_JobGrade + 1;
-                    float maxRequiredRounds = jobMultipler * (nextJobGrade * nextJobGrade);
+                    float currentRequiredRounds = jobMultipler * (currentJob.JobLevel_JobGrade * currentJob.JobLevel_JobGrade); //jobMultipler * nextJobGrade^2
+                    float maxRequiredRounds = jobMultipler * (nextJobGrade * nextJobGrade); //jobMultipler * nextJobGrade^2
                     float totalRoundsCompleted = (int)currentJob.JobLevel_JobExperience / jobExperienceFactor;
-                    //int totalRoundsTillPromotion = maxRequiredRounds - totalRoundsCompleted;
-                    promotionPercentage = totalRoundsCompleted / maxRequiredRounds;
+                    float totalRoundsTillPromotion = maxRequiredRounds - totalRoundsCompleted;
+                    float currentRoundsTotal = maxRequiredRounds - currentRequiredRounds;
+                    promotionPercentage = (currentRoundsTotal - totalRoundsTillPromotion) / currentRoundsTotal;
                 }
 
                 JobInfo = new JobInformation();

--- a/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
+++ b/TSOClient/tso.client/UI/Panels/UIPersonPage.cs
@@ -2,6 +2,7 @@
 using FSO.Client.UI.Controls;
 using FSO.Client.UI.Framework;
 using FSO.Client.UI.Screens;
+using FSO.Client.UI.Profile;
 using FSO.Client.Utils;
 using FSO.Common.DataService.Model;
 using FSO.Common.Utils;
@@ -696,6 +697,10 @@ namespace FSO.Client.UI.Panels
 
         private void ShowJobInfo(UIElement button)
         {
+
+            var jobInfo = new UIJobInfo(JobAlertText);
+            jobInfo.Show();
+
             UIScreen.GlobalShowAlert(new UIAlertOptions()
             {
                 Title = GameFacade.Strings.GetString("189", "64"),

--- a/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
+++ b/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
@@ -1,7 +1,9 @@
 ﻿using FSO.Client.UI.Controls;
 using FSO.Client.UI.Framework;
+using FSO.Common.Utils;
 using FSO.Files;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,17 +13,44 @@ using System.Threading.Tasks;
 
 namespace FSO.Client.UI.Profile
 {
+    public struct JobInformation
+    {
+        public string Title;
+        public string Type;
+        public string Level;
+        public string Hours;
+        public string CarpoolHours;
+        public string NextPosition;
+        public int PromotionPercentage;
+        public bool MaxLevel;
+    }
+
     public class UIJobInfo : UIAlert
     {
-        private UIProgressBar ProgressBar;
         private new UIButton OKButton;
 
-        public UIJobInfo(String jobInformation) : base(new UIAlertOptions()
+        private UILabel Title;
+        
+        private UILabel Type;
+        private UILabel Level;
+        private UILabel Hours;
+        private UILabel CarPoolHours;
+        private UILabel NextPosition;
+        private UIProgressBar ProgressBar;
+
+        private UILabel PositionTitle;
+        private UILabel HoursTitle;
+        private UILabel PerformanceTitle;
+        private UILabel NextPositionTitle;
+
+        private UILabel PromotionRequirements;
+
+        public UIJobInfo(bool maxLevel) : base(new UIAlertOptions()
         {
             Title = "Job Details",
             Width = 400,
-            Height = 400,
-            Message = jobInformation,
+            Height = maxLevel ? 200 : 348,
+            Message = "",
             Buttons = new UIAlertButton[]
             {
                 new UIAlertButton(UIAlertButtonType.OK, (btn) => { }),
@@ -29,18 +58,189 @@ namespace FSO.Client.UI.Profile
             AllowBB = true
         })
         {
+
+            int standardVerticalSpace = 10;
+            int verticalSpace = 40;
+
             OKButton = ButtonMap[UIAlertButtonType.OK];
             OKButton.OnButtonClick += (btn) => Destory();
 
-            ProgressBar = new UIProgressBar()
+            Type = new UILabel();
+            Type.Position = new Vector2(30, verticalSpace);
+            Type.Size = new Vector2(200, 16);
+            Type.CaptionStyle = TextStyle.DefaultTitle;
+            Type.CaptionStyle = Type.CaptionStyle.Clone();
+            Type.CaptionStyle.Color = Color.White;
+            Type.CaptionStyle.Size = 16;
+            Type.CaptionStyle.Shadow = false;
+            Type.Alignment = TextAlignment.Left | TextAlignment.Middle;
+            this.Add(Type);
+            verticalSpace += 16 + standardVerticalSpace;
+
+            int sectionHeight = 54;
+
+            UIImage HoursSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(64, 101, 141), 360, sectionHeight, 6));
+            HoursSectionImage.Position = new Vector2(20, verticalSpace);
+            this.Add(HoursSectionImage);
+            verticalSpace += standardVerticalSpace;
+
+            int hoursTitleSectionHeight = (sectionHeight / 2) - 12 - 6;
+
+            HoursTitle = new UILabel();
+            HoursTitle.Position = new Vector2(40, verticalSpace + hoursTitleSectionHeight);
+            HoursTitle.Size = new Vector2(200, 12);
+            HoursTitle.CaptionStyle = TextStyle.DefaultTitle;
+            HoursTitle.CaptionStyle = HoursTitle.CaptionStyle.Clone();
+            HoursTitle.CaptionStyle.Color = Color.White;
+            HoursTitle.CaptionStyle.Size = 14;
+            HoursTitle.CaptionStyle.Shadow = false;
+            HoursTitle.Alignment = TextAlignment.Left | TextAlignment.Middle;
+            HoursTitle.Caption = "Hours";
+            this.Add(HoursTitle);
+
+            Hours = new UILabel();
+            Hours.Position = new Vector2(40, verticalSpace);
+            Hours.Size = new Vector2(320, 12);
+            Hours.CaptionStyle = TextStyle.DefaultTitle;
+            Hours.CaptionStyle = Hours.CaptionStyle.Clone();
+            Hours.CaptionStyle.Color = Color.White;
+            Hours.CaptionStyle.Size = 14;
+            Hours.CaptionStyle.Shadow = false;
+            Hours.Alignment = TextAlignment.Right | TextAlignment.Middle;
+            this.Add(Hours);
+            verticalSpace += 12 + standardVerticalSpace;
+
+            CarPoolHours = new UILabel();
+            CarPoolHours.Position = new Vector2(40, verticalSpace);
+            CarPoolHours.Size = new Vector2(320, 12);
+            CarPoolHours.CaptionStyle = TextStyle.DefaultTitle;
+            CarPoolHours.CaptionStyle = CarPoolHours.CaptionStyle.Clone();
+            CarPoolHours.CaptionStyle.Color = Color.White;
+            CarPoolHours.CaptionStyle.Size = 14;
+            CarPoolHours.CaptionStyle.Shadow = false;
+            CarPoolHours.Alignment = TextAlignment.Right | TextAlignment.Middle;
+            this.Add(CarPoolHours);
+            verticalSpace += 12 + standardVerticalSpace + standardVerticalSpace;
+
+            UIImage PositionSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(64, 101, 141), 360, sectionHeight, 6));
+            PositionSectionImage.Position = new Vector2(20, verticalSpace);
+            this.Add(PositionSectionImage);
+            verticalSpace += standardVerticalSpace;
+
+            int positionTitleSectionHeight = (sectionHeight / 2) - 12 - 6;
+
+            PositionTitle = new UILabel();
+            PositionTitle.Position = new Vector2(40, verticalSpace + positionTitleSectionHeight);
+            PositionTitle.Size = new Vector2(200, 12);
+            PositionTitle.CaptionStyle = TextStyle.DefaultTitle;
+            PositionTitle.CaptionStyle = PositionTitle.CaptionStyle.Clone();
+            PositionTitle.CaptionStyle.Color = Color.White;
+            PositionTitle.CaptionStyle.Size = 14;
+            PositionTitle.CaptionStyle.Shadow = false;
+            PositionTitle.Alignment = TextAlignment.Left | TextAlignment.Middle;
+            PositionTitle.Caption = "Position";
+            this.Add(PositionTitle);
+
+            Title = new UILabel();
+            Title.Position = new Vector2(40, verticalSpace);
+            Title.Size = new Vector2(320, 12);
+            Title.CaptionStyle = TextStyle.DefaultTitle;
+            Title.CaptionStyle = Title.CaptionStyle.Clone();
+            Title.CaptionStyle.Color = Color.White;
+            Title.CaptionStyle.Size = 14;
+            Title.CaptionStyle.Shadow = false;
+            Title.Alignment = TextAlignment.Right | TextAlignment.Middle;
+            this.Add(Title);
+            verticalSpace += 12 + standardVerticalSpace;
+
+            Level = new UILabel();
+            Level.Position = new Vector2(40, verticalSpace);
+            Level.Size = new Vector2(320, 12);
+            Level.CaptionStyle = TextStyle.DefaultTitle;
+            Level.CaptionStyle = Level.CaptionStyle.Clone();
+            Level.CaptionStyle.Color = Color.White;
+            Level.CaptionStyle.Size = 14;
+            Level.CaptionStyle.Shadow = false;
+            Level.Alignment = TextAlignment.Right | TextAlignment.Middle;
+            this.Add(Level);
+            verticalSpace += 12 + standardVerticalSpace + standardVerticalSpace;
+
+            if (!maxLevel)
             {
-                X = 20,
-                Y = 66,
-                Value = 75
-            };
-            ProgressBar.SetSize(360, 27);
-            ProgressBar.Caption = "Job Performance";
-            this.Add(ProgressBar);
+
+                PromotionRequirements = new UILabel();
+                PromotionRequirements.Position = new Vector2(30, verticalSpace);
+                PromotionRequirements.Size = new Vector2(200, 16);
+                PromotionRequirements.CaptionStyle = TextStyle.DefaultTitle;
+                PromotionRequirements.CaptionStyle = PromotionRequirements.CaptionStyle.Clone();
+                PromotionRequirements.CaptionStyle.Color = Color.White;
+                PromotionRequirements.CaptionStyle.Size = 16;
+                PromotionRequirements.CaptionStyle.Shadow = false;
+                PromotionRequirements.Alignment = TextAlignment.Left | TextAlignment.Middle;
+                PromotionRequirements.Caption = "Promotion Requirements:";
+                this.Add(PromotionRequirements);
+                verticalSpace += 16 + standardVerticalSpace;
+
+                UIImage PerformanceSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(64, 101, 141), 360, sectionHeight, 6));
+                PerformanceSectionImage.Position = new Vector2(20, verticalSpace);
+                this.Add(PerformanceSectionImage);
+
+                int performanceTitleSectionHeight = (sectionHeight / 2) - 8;
+
+                PerformanceTitle = new UILabel();
+                PerformanceTitle.Position = new Vector2(40, verticalSpace + performanceTitleSectionHeight);
+                PerformanceTitle.Size = new Vector2(200, 12);
+                PerformanceTitle.CaptionStyle = TextStyle.DefaultTitle;
+                PerformanceTitle.CaptionStyle = PerformanceTitle.CaptionStyle.Clone();
+                PerformanceTitle.CaptionStyle.Color = Color.White;
+                PerformanceTitle.CaptionStyle.Size = 14;
+                PerformanceTitle.CaptionStyle.Shadow = false;
+                PerformanceTitle.Alignment = TextAlignment.Left | TextAlignment.Middle;
+                PerformanceTitle.Caption = "Performance";
+                this.Add(PerformanceTitle);
+
+                ProgressBar = new UIProgressBar()
+                {
+                    X = 360 - 180,
+                    Y = verticalSpace + performanceTitleSectionHeight - 6,
+                    Value = 75
+                };
+                ProgressBar.SetSize(185, 27);
+                ProgressBar.Caption = "";
+                ProgressBar.Background = TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(58, 89, 122), 190, 27, 12);
+                this.Add(ProgressBar);
+
+                verticalSpace += sectionHeight + standardVerticalSpace;
+
+                UIImage NextPositionSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(64, 101, 141), 360, sectionHeight, 6));
+                NextPositionSectionImage.Position = new Vector2(20, verticalSpace);
+                this.Add(NextPositionSectionImage);
+
+                int nextPositionTitleSectionHeight = (sectionHeight / 2) - 8;
+
+                NextPositionTitle = new UILabel();
+                NextPositionTitle.Position = new Vector2(40, verticalSpace + nextPositionTitleSectionHeight);
+                NextPositionTitle.Size = new Vector2(200, 12);
+                NextPositionTitle.CaptionStyle = TextStyle.DefaultTitle;
+                NextPositionTitle.CaptionStyle = NextPositionTitle.CaptionStyle.Clone();
+                NextPositionTitle.CaptionStyle.Color = Color.White;
+                NextPositionTitle.CaptionStyle.Size = 14;
+                NextPositionTitle.CaptionStyle.Shadow = false;
+                NextPositionTitle.Alignment = TextAlignment.Left | TextAlignment.Middle;
+                NextPositionTitle.Caption = "Next Position";
+                this.Add(NextPositionTitle);
+
+                NextPosition = new UILabel();
+                NextPosition.Position = new Vector2(40, verticalSpace + nextPositionTitleSectionHeight);
+                NextPosition.Size = new Vector2(320, 12);
+                NextPosition.CaptionStyle = TextStyle.DefaultTitle;
+                NextPosition.CaptionStyle = NextPosition.CaptionStyle.Clone();
+                NextPosition.CaptionStyle.Color = Color.White;
+                NextPosition.CaptionStyle.Size = 14;
+                NextPosition.CaptionStyle.Shadow = false;
+                NextPosition.Alignment = TextAlignment.Right | TextAlignment.Middle;
+                this.Add(NextPosition);
+            }
         }
 
         public override void Removed()
@@ -49,9 +249,19 @@ namespace FSO.Client.UI.Profile
             Icon.Texture?.Dispose();
         }
 
-        public void Show()
+        public void Show(JobInformation JobInfo)
         {
-            GlobalShowDialog(this, false);
+            Title.Caption = JobInfo.Title;
+            Type.Caption = JobInfo.Type;
+            Hours.Caption = JobInfo.Hours;
+            Level.Caption = JobInfo.Level;
+            CarPoolHours.Caption = JobInfo.CarpoolHours;
+            if (!JobInfo.MaxLevel)
+            {
+                NextPosition.Caption = JobInfo.NextPosition;
+                ProgressBar.Value = JobInfo.PromotionPercentage;
+            }
+            ShowDialog(this, false);
             this.CenterAround(UIScreen.Current, -(int)UIScreen.Current.X * 2, -(int)UIScreen.Current.Y * 2);
         }
 
@@ -60,7 +270,7 @@ namespace FSO.Client.UI.Profile
             UIScreen.RemoveDialog(this);
         }
 
-        public static void GlobalShowDialog(UIElement dialog, bool modal)
+        public static void ShowDialog(UIElement dialog, bool modal)
         {
             GlobalShowDialog(new DialogReference
             {

--- a/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
+++ b/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
@@ -116,6 +116,7 @@ namespace FSO.Client.UI.Profile
 
             int standardVerticalSpace = 10;
             int verticalSpace = 40;
+            int sectionHeight = 54;
 
             OKButton = ButtonMap[UIAlertButtonType.OK];
             OKButton.OnButtonClick += (btn) => Destory();
@@ -133,8 +134,6 @@ namespace FSO.Client.UI.Profile
             Type.Alignment = TextAlignment.Left | TextAlignment.Middle;
             this.Add(Type);
             verticalSpace += 16 + standardVerticalSpace;
-
-            int sectionHeight = 54;
 
             UIImage HoursSectionImage = new UIImage(GetTexture((ulong)0x7A400000001)).With9Slice(13, 13, 13, 13);
             HoursSectionImage.SetSize(360, sectionHeight);
@@ -277,16 +276,17 @@ namespace FSO.Client.UI.Profile
                 PerformanceTitle.Caption = "Performance";
                 this.Add(PerformanceTitle);
 
-                int progressBarWidth = 180;
+                int progressBarWidth = 145;
                 ProgressBar = new UIProgressBar()
                 {
-                    X = 360 - 180,
-                    Y = verticalSpace + performanceTitleSectionHeight - 6,
-                    Value = 75
+                    X = 360 - progressBarWidth,
+                    Y = verticalSpace + performanceTitleSectionHeight - 5,
+                    Value = 0
                 };
                 ProgressBar.SetSize(progressBarWidth, 27);
                 ProgressBar.Caption = "";
-                ProgressBar.Background = TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(64, 101, 141), progressBarWidth, 27, 12);
+                
+                ProgressBar.Background = TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(37, 58, 77), progressBarWidth, 27, 9);
                 this.Add(ProgressBar);
 
                 verticalSpace += sectionHeight + standardVerticalSpace;

--- a/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
+++ b/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
@@ -1,0 +1,82 @@
+﻿using FSO.Client.UI.Controls;
+using FSO.Client.UI.Framework;
+using FSO.Files;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSO.Client.UI.Profile
+{
+    public class UIJobInfo : UIAlert
+    {
+        private UIProgressBar ProgressBar;
+        private new UIButton OKButton;
+
+        public UIJobInfo(String jobInformation) : base(new UIAlertOptions()
+        {
+            Title = "Job Details",
+            Width = 400,
+            Height = 400,
+            Message = jobInformation,
+            Buttons = new UIAlertButton[]
+            {
+                new UIAlertButton(UIAlertButtonType.OK, (btn) => { }),
+            },
+            AllowBB = true
+        })
+        {
+            OKButton = ButtonMap[UIAlertButtonType.OK];
+            OKButton.OnButtonClick += (btn) => Destory();
+
+            ProgressBar = new UIProgressBar()
+            {
+                X = 20,
+                Y = 66,
+                Value = 75
+            };
+            ProgressBar.SetSize(360, 27);
+            ProgressBar.Caption = "Job Performance";
+            this.Add(ProgressBar);
+        }
+
+        public override void Removed()
+        {
+            base.Removed();
+            Icon.Texture?.Dispose();
+        }
+
+        public void Show()
+        {
+            GlobalShowDialog(this, false);
+            this.CenterAround(UIScreen.Current, -(int)UIScreen.Current.X * 2, -(int)UIScreen.Current.Y * 2);
+        }
+
+        public void Destory()
+        {
+            UIScreen.RemoveDialog(this);
+        }
+
+        public static void GlobalShowDialog(UIElement dialog, bool modal)
+        {
+            GlobalShowDialog(new DialogReference
+            {
+                Dialog = dialog,
+                Modal = modal
+            });
+        }
+
+        public static void GlobalShowDialog(DialogReference dialog)
+        {
+            GameFacade.Screens.AddDialog(dialog);
+
+            if (dialog.Dialog is UIDialog)
+            {
+                ((UIDialog)dialog.Dialog).CenterAround(UIScreen.Current, -(int)UIScreen.Current.X * 2, -(int)UIScreen.Current.Y * 2);
+            }
+        }
+    }
+}

--- a/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
+++ b/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
@@ -136,10 +136,10 @@ namespace FSO.Client.UI.Profile
 
             int sectionHeight = 54;
 
-            UIImage HoursSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6))
-            {
-                Position = new Vector2(20, verticalSpace)
-            };
+            UIImage HoursSectionImage = new UIImage(GetTexture((ulong)0x7A400000001)).With9Slice(13, 13, 13, 13);
+            HoursSectionImage.SetSize(360, sectionHeight);
+            HoursSectionImage.Position = new Vector2(20, verticalSpace);
+            Add(HoursSectionImage);
             this.Add(HoursSectionImage);
             verticalSpace += standardVerticalSpace;
 
@@ -187,10 +187,10 @@ namespace FSO.Client.UI.Profile
             this.Add(CarPoolHours);
             verticalSpace += 12 + standardVerticalSpace + standardVerticalSpace;
 
-            UIImage PositionSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6))
-            {
-                Position = new Vector2(20, verticalSpace)
-            };
+            UIImage PositionSectionImage = new UIImage(GetTexture((ulong)0x7A400000001)).With9Slice(13, 13, 13, 13);
+            PositionSectionImage.SetSize(360, sectionHeight);
+            PositionSectionImage.Position = new Vector2(20, verticalSpace);
+            Add(PositionSectionImage);
             this.Add(PositionSectionImage);
             verticalSpace += standardVerticalSpace;
 
@@ -255,10 +255,10 @@ namespace FSO.Client.UI.Profile
                 this.Add(PromotionRequirements);
                 verticalSpace += 16 + standardVerticalSpace;
 
-                UIImage PerformanceSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6))
-                {
-                    Position = new Vector2(20, verticalSpace)
-                };
+                UIImage PerformanceSectionImage = new UIImage(GetTexture((ulong)0x7A400000001)).With9Slice(13, 13, 13, 13);
+                PerformanceSectionImage.SetSize(360, sectionHeight);
+                PerformanceSectionImage.Position = new Vector2(20, verticalSpace);
+                Add(PerformanceSectionImage);
                 this.Add(PerformanceSectionImage);
 
                 int performanceTitleSectionHeight = (sectionHeight / 2) - 8;
@@ -277,23 +277,24 @@ namespace FSO.Client.UI.Profile
                 PerformanceTitle.Caption = "Performance";
                 this.Add(PerformanceTitle);
 
+                int progressBarWidth = 180;
                 ProgressBar = new UIProgressBar()
                 {
                     X = 360 - 180,
                     Y = verticalSpace + performanceTitleSectionHeight - 6,
                     Value = 75
                 };
-                ProgressBar.SetSize(185, 27);
+                ProgressBar.SetSize(progressBarWidth, 27);
                 ProgressBar.Caption = "";
-                ProgressBar.Background = TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(64, 101, 141), 190, 27, 12);
+                ProgressBar.Background = TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(64, 101, 141), progressBarWidth, 27, 12);
                 this.Add(ProgressBar);
 
                 verticalSpace += sectionHeight + standardVerticalSpace;
 
-                UIImage NextPositionSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6))
-                {
-                    Position = new Vector2(20, verticalSpace)
-                };
+                UIImage NextPositionSectionImage = new UIImage(GetTexture((ulong)0x7A400000001)).With9Slice(13, 13, 13, 13);
+                NextPositionSectionImage.SetSize(360, sectionHeight);
+                NextPositionSectionImage.Position = new Vector2(20, verticalSpace);
+                Add(NextPositionSectionImage);
                 this.Add(NextPositionSectionImage);
 
                 int nextPositionTitleSectionHeight = (sectionHeight / 2) - 8;

--- a/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
+++ b/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
@@ -24,7 +24,7 @@ namespace FSO.Client.UI.Profile
         public int PromotionPercentage;
         public bool MaxLevel;
 
-        public JobInformation(int jobGrade, int jobType, int jobExperience) //Let's assume JobLevel = JobGrade?
+        public JobInformation(int jobGrade, int jobType, int jobExperience)
         {
             int poolTime = Math.Min(2, jobType - 1);
             int jobMultipler = -1;
@@ -120,10 +120,12 @@ namespace FSO.Client.UI.Profile
             OKButton = ButtonMap[UIAlertButtonType.OK];
             OKButton.OnButtonClick += (btn) => Destory();
 
-            Type = new UILabel();
-            Type.Position = new Vector2(30, verticalSpace);
-            Type.Size = new Vector2(200, 16);
-            Type.CaptionStyle = TextStyle.DefaultTitle;
+            Type = new UILabel
+            {
+                Position = new Vector2(30, verticalSpace),
+                Size = new Vector2(200, 16),
+                CaptionStyle = TextStyle.DefaultTitle
+            };
             Type.CaptionStyle = Type.CaptionStyle.Clone();
             Type.CaptionStyle.Color = Color.White;
             Type.CaptionStyle.Size = 16;
@@ -134,17 +136,21 @@ namespace FSO.Client.UI.Profile
 
             int sectionHeight = 54;
 
-            UIImage HoursSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6));
-            HoursSectionImage.Position = new Vector2(20, verticalSpace);
+            UIImage HoursSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6))
+            {
+                Position = new Vector2(20, verticalSpace)
+            };
             this.Add(HoursSectionImage);
             verticalSpace += standardVerticalSpace;
 
             int hoursTitleSectionHeight = (sectionHeight / 2) - 12 - 6;
 
-            HoursTitle = new UILabel();
-            HoursTitle.Position = new Vector2(40, verticalSpace + hoursTitleSectionHeight);
-            HoursTitle.Size = new Vector2(200, 12);
-            HoursTitle.CaptionStyle = TextStyle.DefaultTitle;
+            HoursTitle = new UILabel
+            {
+                Position = new Vector2(40, verticalSpace + hoursTitleSectionHeight),
+                Size = new Vector2(200, 12),
+                CaptionStyle = TextStyle.DefaultTitle
+            };
             HoursTitle.CaptionStyle = HoursTitle.CaptionStyle.Clone();
             HoursTitle.CaptionStyle.Color = new Color(238, 247, 169);
             HoursTitle.CaptionStyle.Size = 14;
@@ -153,10 +159,12 @@ namespace FSO.Client.UI.Profile
             HoursTitle.Caption = "Hours";
             this.Add(HoursTitle);
 
-            Hours = new UILabel();
-            Hours.Position = new Vector2(40, verticalSpace);
-            Hours.Size = new Vector2(320, 12);
-            Hours.CaptionStyle = TextStyle.DefaultTitle;
+            Hours = new UILabel
+            {
+                Position = new Vector2(40, verticalSpace),
+                Size = new Vector2(320, 12),
+                CaptionStyle = TextStyle.DefaultTitle
+            };
             Hours.CaptionStyle = Hours.CaptionStyle.Clone();
             Hours.CaptionStyle.Color = new Color(238, 247, 169);
             Hours.CaptionStyle.Size = 12;
@@ -165,10 +173,12 @@ namespace FSO.Client.UI.Profile
             this.Add(Hours);
             verticalSpace += 12 + standardVerticalSpace;
 
-            CarPoolHours = new UILabel();
-            CarPoolHours.Position = new Vector2(40, verticalSpace);
-            CarPoolHours.Size = new Vector2(320, 12);
-            CarPoolHours.CaptionStyle = TextStyle.DefaultTitle;
+            CarPoolHours = new UILabel
+            {
+                Position = new Vector2(40, verticalSpace),
+                Size = new Vector2(320, 12),
+                CaptionStyle = TextStyle.DefaultTitle
+            };
             CarPoolHours.CaptionStyle = CarPoolHours.CaptionStyle.Clone();
             CarPoolHours.CaptionStyle.Color = new Color(238, 247, 169);
             CarPoolHours.CaptionStyle.Size = 12;
@@ -177,17 +187,21 @@ namespace FSO.Client.UI.Profile
             this.Add(CarPoolHours);
             verticalSpace += 12 + standardVerticalSpace + standardVerticalSpace;
 
-            UIImage PositionSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6));
-            PositionSectionImage.Position = new Vector2(20, verticalSpace);
+            UIImage PositionSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6))
+            {
+                Position = new Vector2(20, verticalSpace)
+            };
             this.Add(PositionSectionImage);
             verticalSpace += standardVerticalSpace;
 
             int positionTitleSectionHeight = (sectionHeight / 2) - 12 - 6;
 
-            PositionTitle = new UILabel();
-            PositionTitle.Position = new Vector2(40, verticalSpace + positionTitleSectionHeight);
-            PositionTitle.Size = new Vector2(200, 12);
-            PositionTitle.CaptionStyle = TextStyle.DefaultTitle;
+            PositionTitle = new UILabel
+            {
+                Position = new Vector2(40, verticalSpace + positionTitleSectionHeight),
+                Size = new Vector2(200, 12),
+                CaptionStyle = TextStyle.DefaultTitle
+            };
             PositionTitle.CaptionStyle = PositionTitle.CaptionStyle.Clone();
             PositionTitle.CaptionStyle.Color = new Color(238, 247, 169);
             PositionTitle.CaptionStyle.Size = 14;
@@ -196,10 +210,12 @@ namespace FSO.Client.UI.Profile
             PositionTitle.Caption = "Position";
             this.Add(PositionTitle);
 
-            Title = new UILabel();
-            Title.Position = new Vector2(40, verticalSpace);
-            Title.Size = new Vector2(320, 12);
-            Title.CaptionStyle = TextStyle.DefaultTitle;
+            Title = new UILabel
+            {
+                Position = new Vector2(40, verticalSpace),
+                Size = new Vector2(320, 12),
+                CaptionStyle = TextStyle.DefaultTitle
+            };
             Title.CaptionStyle = Title.CaptionStyle.Clone();
             Title.CaptionStyle.Color = new Color(238, 247, 169);
             Title.CaptionStyle.Size = 12;
@@ -208,10 +224,12 @@ namespace FSO.Client.UI.Profile
             this.Add(Title);
             verticalSpace += 12 + standardVerticalSpace;
 
-            Level = new UILabel();
-            Level.Position = new Vector2(40, verticalSpace);
-            Level.Size = new Vector2(320, 12);
-            Level.CaptionStyle = TextStyle.DefaultTitle;
+            Level = new UILabel
+            {
+                Position = new Vector2(40, verticalSpace),
+                Size = new Vector2(320, 12),
+                CaptionStyle = TextStyle.DefaultTitle
+            };
             Level.CaptionStyle = Level.CaptionStyle.Clone();
             Level.CaptionStyle.Color = new Color(238, 247, 169);
             Level.CaptionStyle.Size = 12;
@@ -222,10 +240,12 @@ namespace FSO.Client.UI.Profile
 
             if (!jobInformation.MaxLevel)
             {
-                PromotionRequirements = new UILabel();
-                PromotionRequirements.Position = new Vector2(30, verticalSpace);
-                PromotionRequirements.Size = new Vector2(200, 16);
-                PromotionRequirements.CaptionStyle = TextStyle.DefaultTitle;
+                PromotionRequirements = new UILabel
+                {
+                    Position = new Vector2(30, verticalSpace),
+                    Size = new Vector2(200, 16),
+                    CaptionStyle = TextStyle.DefaultTitle
+                };
                 PromotionRequirements.CaptionStyle = PromotionRequirements.CaptionStyle.Clone();
                 PromotionRequirements.CaptionStyle.Color = Color.White;
                 PromotionRequirements.CaptionStyle.Size = 16;
@@ -235,16 +255,20 @@ namespace FSO.Client.UI.Profile
                 this.Add(PromotionRequirements);
                 verticalSpace += 16 + standardVerticalSpace;
 
-                UIImage PerformanceSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6));
-                PerformanceSectionImage.Position = new Vector2(20, verticalSpace);
+                UIImage PerformanceSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6))
+                {
+                    Position = new Vector2(20, verticalSpace)
+                };
                 this.Add(PerformanceSectionImage);
 
                 int performanceTitleSectionHeight = (sectionHeight / 2) - 8;
 
-                PerformanceTitle = new UILabel();
-                PerformanceTitle.Position = new Vector2(40, verticalSpace + performanceTitleSectionHeight);
-                PerformanceTitle.Size = new Vector2(200, 12);
-                PerformanceTitle.CaptionStyle = TextStyle.DefaultTitle;
+                PerformanceTitle = new UILabel
+                {
+                    Position = new Vector2(40, verticalSpace + performanceTitleSectionHeight),
+                    Size = new Vector2(200, 12),
+                    CaptionStyle = TextStyle.DefaultTitle
+                };
                 PerformanceTitle.CaptionStyle = PerformanceTitle.CaptionStyle.Clone();
                 PerformanceTitle.CaptionStyle.Color = new Color(238, 247, 169);
                 PerformanceTitle.CaptionStyle.Size = 14;
@@ -266,16 +290,20 @@ namespace FSO.Client.UI.Profile
 
                 verticalSpace += sectionHeight + standardVerticalSpace;
 
-                UIImage NextPositionSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6));
-                NextPositionSectionImage.Position = new Vector2(20, verticalSpace);
+                UIImage NextPositionSectionImage = new UIImage(TextureGenerator.GenerateRoundedRectangle(GameFacade.GraphicsDevice, new Color(59, 84, 116), 360, sectionHeight, 6))
+                {
+                    Position = new Vector2(20, verticalSpace)
+                };
                 this.Add(NextPositionSectionImage);
 
                 int nextPositionTitleSectionHeight = (sectionHeight / 2) - 8;
 
-                NextPositionTitle = new UILabel();
-                NextPositionTitle.Position = new Vector2(40, verticalSpace + nextPositionTitleSectionHeight);
-                NextPositionTitle.Size = new Vector2(200, 12);
-                NextPositionTitle.CaptionStyle = TextStyle.DefaultTitle;
+                NextPositionTitle = new UILabel
+                {
+                    Position = new Vector2(40, verticalSpace + nextPositionTitleSectionHeight),
+                    Size = new Vector2(200, 12),
+                    CaptionStyle = TextStyle.DefaultTitle
+                };
                 NextPositionTitle.CaptionStyle = NextPositionTitle.CaptionStyle.Clone();
                 NextPositionTitle.CaptionStyle.Color = new Color(238, 247, 169);
                 NextPositionTitle.CaptionStyle.Size = 14;
@@ -284,10 +312,12 @@ namespace FSO.Client.UI.Profile
                 NextPositionTitle.Caption = "Next Position";
                 this.Add(NextPositionTitle);
 
-                NextPosition = new UILabel();
-                NextPosition.Position = new Vector2(40, verticalSpace + nextPositionTitleSectionHeight);
-                NextPosition.Size = new Vector2(320, 12);
-                NextPosition.CaptionStyle = TextStyle.DefaultTitle;
+                NextPosition = new UILabel
+                {
+                    Position = new Vector2(40, verticalSpace + nextPositionTitleSectionHeight),
+                    Size = new Vector2(320, 12),
+                    CaptionStyle = TextStyle.DefaultTitle
+                };
                 NextPosition.CaptionStyle = NextPosition.CaptionStyle.Clone();
                 NextPosition.CaptionStyle.Color = new Color(238, 247, 169);
                 NextPosition.CaptionStyle.Size = 12;

--- a/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
+++ b/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
@@ -167,7 +167,6 @@ namespace FSO.Client.UI.Profile
 
             if (!maxLevel)
             {
-
                 PromotionRequirements = new UILabel();
                 PromotionRequirements.Position = new Vector2(30, verticalSpace);
                 PromotionRequirements.Size = new Vector2(200, 16);

--- a/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
+++ b/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace FSO.Client.UI.Profile
+namespace FSO.Client.UI.Panels.Profile
 {
     public struct JobInformation
     {
@@ -119,7 +119,7 @@ namespace FSO.Client.UI.Profile
             int sectionHeight = 54;
 
             OKButton = ButtonMap[UIAlertButtonType.OK];
-            OKButton.OnButtonClick += (btn) => Destory();
+            OKButton.OnButtonClick += (btn) => Destroy();
 
             Type = new UILabel
             {
@@ -151,9 +151,9 @@ namespace FSO.Client.UI.Profile
                 CaptionStyle = TextStyle.DefaultTitle
             };
             HoursTitle.CaptionStyle = HoursTitle.CaptionStyle.Clone();
-            HoursTitle.CaptionStyle.Color = new Color(238, 247, 169);
+            //HoursTitle.CaptionStyle.Color = new Color(238, 247, 169);
             HoursTitle.CaptionStyle.Size = 14;
-            HoursTitle.CaptionStyle.Shadow = false;
+            //HoursTitle.CaptionStyle.Shadow = false;
             HoursTitle.Alignment = TextAlignment.Left | TextAlignment.Middle;
             HoursTitle.Caption = "Hours";
             this.Add(HoursTitle);
@@ -331,7 +331,7 @@ namespace FSO.Client.UI.Profile
         public override void Removed()
         {
             base.Removed();
-            Icon.Texture?.Dispose();
+            ProgressBar.Background.Dispose();
         }
 
         public void Show()
@@ -346,32 +346,13 @@ namespace FSO.Client.UI.Profile
                 NextPosition.Caption = jobInformation.NextPosition;
                 ProgressBar.Value = jobInformation.PromotionPercentage;
             }
-            ShowDialog(this, false);
+            UIScreen.GlobalShowDialog(this, false);
             this.CenterAround(UIScreen.Current, -(int)UIScreen.Current.X * 2, -(int)UIScreen.Current.Y * 2);
         }
 
-        public void Destory()
+        public void Destroy()
         {
             UIScreen.RemoveDialog(this);
-        }
-
-        public static void ShowDialog(UIElement dialog, bool modal)
-        {
-            ShowDialog(new DialogReference
-            {
-                Dialog = dialog,
-                Modal = modal
-            });
-        }
-
-        public static void ShowDialog(DialogReference dialog)
-        {
-            GameFacade.Screens.AddDialog(dialog);
-
-            if (dialog.Dialog is UIDialog)
-            {
-                ((UIDialog)dialog.Dialog).CenterAround(UIScreen.Current, -(int)UIScreen.Current.X * 2, -(int)UIScreen.Current.Y * 2);
-            }
         }
     }
 }

--- a/TSOClient/tso.simantics/primitives/VMDialogPrivateStrings.cs
+++ b/TSOClient/tso.simantics/primitives/VMDialogPrivateStrings.cs
@@ -270,10 +270,11 @@ namespace FSO.SimAntics.Primitives
         TS1Magictown = 13,
         TS1TransformMe = 14,
         TS1Cookbook = 15,
-        
+
+        FSOJob = 127,
         FSOColor = 128,
         FSOChars = 129,
-        FSOJob = 130
+        
     }
 
     public class VMDialogResult : VMAsyncState

--- a/TSOClient/tso.simantics/primitives/VMDialogPrivateStrings.cs
+++ b/TSOClient/tso.simantics/primitives/VMDialogPrivateStrings.cs
@@ -272,7 +272,8 @@ namespace FSO.SimAntics.Primitives
         TS1Cookbook = 15,
         
         FSOColor = 128,
-        FSOChars = 129
+        FSOChars = 129,
+        FSOJob = 130
     }
 
     public class VMDialogResult : VMAsyncState


### PR DESCRIPTION
This PR adds a new UIJobInfo class that is able to take in variables from both the UIPersonPage and UILotControl (Job Grade [Level], Job Type, and Total Cumulative Experience Points), and display a nicer looking UI and provide some additional information that is helpful as you progress through your job. The two new bits of information is what you current job level is, and your performance, which is a progress bar, that gives you a % till promotion.

These changes have been extensively tested on all the current job career paths and tested on various roll overs from one grade to another.

This is my first UI element addition to FreeSO, so I did my best to make it look as nice as I could, and match the required look and feel of FreeSO / TSO. Please let me know here if you have any additional feedback or suggestions; or find me on Discord.

Here is how the current dialog looks when you retrieve it by phone call:
<img width="286" alt="Current Dialog" src="https://user-images.githubusercontent.com/6549835/54869912-2e980700-4d6d-11e9-8f0f-d753f89ac235.PNG">

And here is the new version of the dialog (called with a different sim):
<img width="317" alt="New Dialog" src="https://user-images.githubusercontent.com/6549835/54869924-4d969900-4d6d-11e9-985a-49bf17e7789d.PNG">

Currently for this update, if you are unemployed, you will still see the previous style dialog:
<img width="275" alt="Current Unemployed Dialog" src="https://user-images.githubusercontent.com/6549835/54869928-5d15e200-4d6d-11e9-9b87-ddb344c85def.PNG">

Here are a few more additional screenshots with different job grades and job types:
<img width="324" alt="Extra Screenshot 1" src="https://user-images.githubusercontent.com/6549835/54869932-7cad0a80-4d6d-11e9-9f46-3283c21c0c37.PNG">
<img width="315" alt="Extra Screenshot 2" src="https://user-images.githubusercontent.com/6549835/54869935-846caf00-4d6d-11e9-9834-7eb3a0eafed8.PNG">
<img width="314" alt="Extra Screenshot 3" src="https://user-images.githubusercontent.com/6549835/54869937-964e5200-4d6d-11e9-8348-f5ceffaef337.PNG">
<img width="317" alt="Extra Screenshot 4" src="https://user-images.githubusercontent.com/6549835/54869941-afef9980-4d6d-11e9-802d-1c6442e1a732.PNG">

- Jones



