### PR TITLE
Fixing Accidental Sale from Price Dialog

### DIFF
--- a/TSOClient/tso.client/UI/Panels/UIAsyncPriceDialog.cs
+++ b/TSOClient/tso.client/UI/Panels/UIAsyncPriceDialog.cs
@@ -12,7 +12,10 @@ namespace FSO.Client.UI.Panels
     public class UIAsyncPriceDialog : UIDialog
     {
         public delegate void SalePriceDelegate(uint SalePrice);
+        public delegate void SalePriceCanceledDelegate();
         public event SalePriceDelegate OnPriceChange;
+        public event SalePriceCanceledDelegate OnPriceChangeCancel;
+
         public UITextEdit ForSalePrice { get; set; }
         public UITextEdit topText { get; set; }
 
@@ -28,10 +31,13 @@ namespace FSO.Client.UI.Panels
             ForSalePrice.CurrentText = originalPrice.ToString();
             OKButton.OnButtonClick += OKClicked;
             CloseButton.OnButtonClick += CloseClicked;
+
+            GameFacade.Screens.inputManager.SetFocus(ForSalePrice);
         }
 
         private void CloseClicked(UIElement button)
         {
+            OnPriceChangeCancel?.Invoke();
             UIScreen.RemoveDialog(this);
         }
 

--- a/TSOClient/tso.client/UI/Panels/UIAsyncPriceDialog.cs
+++ b/TSOClient/tso.client/UI/Panels/UIAsyncPriceDialog.cs
@@ -12,9 +12,7 @@ namespace FSO.Client.UI.Panels
     public class UIAsyncPriceDialog : UIDialog
     {
         public delegate void SalePriceDelegate(uint SalePrice);
-        public delegate void SalePriceCanceledDelegate();
         public event SalePriceDelegate OnPriceChange;
-        public event SalePriceCanceledDelegate OnPriceChangeCancel;
 
         public UITextEdit ForSalePrice { get; set; }
         public UITextEdit topText { get; set; }
@@ -37,7 +35,6 @@ namespace FSO.Client.UI.Panels
 
         private void CloseClicked(UIElement button)
         {
-            OnPriceChangeCancel?.Invoke();
             UIScreen.RemoveDialog(this);
         }
 

--- a/TSOClient/tso.client/UI/Panels/UIObjectHolder.cs
+++ b/TSOClient/tso.client/UI/Panels/UIObjectHolder.cs
@@ -56,8 +56,6 @@ namespace FSO.Client.UI.Panels
 
         public UIObjectSelection Holding;
 
-        private UIAsyncPriceDialog PriceDialog;
-
         public UIObjectHolder(VM vm, LotView.World World, UILotControl parent)
         {
             this.vm = vm;
@@ -375,23 +373,20 @@ namespace FSO.Client.UI.Panels
                 var movable = obj.IsUserMovable(vm.Context, true);
                 if (movable == VMPlacementError.Success)
                 {
-                    PriceDialog = new UIAsyncPriceDialog(obj.ToString(), (obj.MultitileGroup.Price<0)?0:(uint)obj.MultitileGroup.Price);
-                    PriceDialog.OnPriceChange += (uint salePrice) =>
+                    var dialog = new UIAsyncPriceDialog(obj.ToString(), (obj.MultitileGroup.Price<0)?0:(uint)obj.MultitileGroup.Price);
+                    dialog.OnPriceChange += (uint salePrice) =>
                     {
                         vm.SendCommand(new VMNetAsyncPriceCmd
                         {
                             NewPrice = (int)Math.Min(int.MaxValue, salePrice),
                             ObjectPID = obj.PersistID
                         });
-                        PriceDialog = null;
+
+                        OnDelete(Holding, null);
+                        ClearSelected();
                     };
 
-                    PriceDialog.OnPriceChangeCancel += () =>
-                    {
-                        PriceDialog = null;
-                    };
-
-                    UIScreen.GlobalShowDialog(PriceDialog, true);
+                    UIScreen.GlobalShowDialog(dialog, true);
                 }
                 else ShowErrorAtMouse(LastState, movable);
             }
@@ -432,7 +427,7 @@ namespace FSO.Client.UI.Panels
                 if (Roommate) cur = CursorType.SimsPlace;
                 if (state.KeyboardState.IsKeyDown(Keys.Delete))
                 {
-                    if(PriceDialog == null)
+                    if (state.InputManager.GetFocus() == null)
                     {
                         SellBack(null);
                     }


### PR DESCRIPTION
This change prevents a player from accidentally deleting an item when setting the SalePrice via the delete key.

Most people are familiar with using a combination of delete and backspace in-order to edit text in a textfield, this will prevent the accident that everyone has done at least once, of pressing delete and selling a very expensive item.

Additionally one very small UI/UX enhancement was made, in that when you select "Set for Sale", and the dialog is presented, your cursor is automatically focused in and ready to adjust the price.

Implementation: I actually really thought about the best way to take care of this situation. My initial implementation used on focus events to track the dialog and the focus of the ForSalePrice UITextEdit. But in the end I wanted to make sure that the PriceDialog was getting de-allocated correctly, and remove focus. The submitted code seemed like the best of all worlds for memory management and user experience.

Tested in various states: Placing Multiple Items, Setting Multiple Items for Sale, Deleting after an item is set for sale or canceled.