### PR TITLE
[Bug Fixes] JobUI Crashes and Unreliable Phone Results

### DIFF
--- a/TSOClient/tso.client/UI/Panels/UILotControl.cs
+++ b/TSOClient/tso.client/UI/Panels/UILotControl.cs
@@ -47,6 +47,7 @@ using FSO.Client.Network;
 using FSO.Client.UI.Panels.Neighborhoods;
 using FSO.UI.Controls;
 using FSO.Client.UI.Panels.Profile;
+using FSO.SimAntics.Model;
 
 namespace FSO.Client.UI.Panels
 {
@@ -325,16 +326,9 @@ namespace FSO.Client.UI.Panels
                     break;
                 case VMDialogType.FSOJob:
                     VMAvatar avatar = (VMAvatar)info.Caller;
-
-                    //Find their current active job
-                    VMTSOAvatarState state = (VMTSOAvatarState)avatar.TSOState;
-                    KeyValuePair<short, VMTSOJobInfo> jobInfo = state.JobInfo.FirstOrDefault(x => x.Value.StatusFlags == 1);
-                    if (jobInfo.Key != 0)
-                    {
-                        JobInformation JobInfo = new JobInformation((int)jobInfo.Value.Level, (int)jobInfo.Key, (int)jobInfo.Value.Experience); //Job Grade, Job Type, Experience
-                        var jobInfoAlert = new UIJobInfo(JobInfo);
-                        jobInfoAlert.Show();
-                    }
+                    JobInformation JobInfo = new JobInformation((int)avatar.GetPersonData(VMPersonDataVariable.OnlineJobGrade), (int)avatar.GetPersonData(VMPersonDataVariable.OnlineJobID), (int)avatar.GetPersonData(VMPersonDataVariable.OnlineJobXP));
+                    var jobInfoAlert = new UIJobInfo(JobInfo);
+                    jobInfoAlert.Show();
                     return;
             }
 

--- a/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
+++ b/TSOClient/tso.client/UI/Profile/UIJobInfo.cs
@@ -151,9 +151,7 @@ namespace FSO.Client.UI.Panels.Profile
                 CaptionStyle = TextStyle.DefaultTitle
             };
             HoursTitle.CaptionStyle = HoursTitle.CaptionStyle.Clone();
-            //HoursTitle.CaptionStyle.Color = new Color(238, 247, 169);
             HoursTitle.CaptionStyle.Size = 14;
-            //HoursTitle.CaptionStyle.Shadow = false;
             HoursTitle.Alignment = TextAlignment.Left | TextAlignment.Middle;
             HoursTitle.Caption = "Hours";
             this.Add(HoursTitle);
@@ -331,7 +329,7 @@ namespace FSO.Client.UI.Panels.Profile
         public override void Removed()
         {
             base.Removed();
-            ProgressBar.Background.Dispose();
+            ProgressBar?.Background?.Dispose();
         }
 
         public void Show()


### PR DESCRIPTION
Fixing two bugs that were discovered in #bug-reports:
- Max Level players crash when looking at their job history, due to the progress bar not being allocated for them and it blowing up on the `destroy()`
- Telephone users with multiple jobs are getting unexpected job results. Switching the logic over `GetPersonData` is more reliable and follows similar paradigms of other controllers.
- Minor commented out code clean-up that was missed previously.

Sorry for the bugs!