### PR TITLE
Press I to inventory an item, while it's being held.

### DIFF
--- a/TSOClient/tso.client/UI/Panels/UIObjectHolder.cs
+++ b/TSOClient/tso.client/UI/Panels/UIObjectHolder.cs
@@ -436,6 +436,12 @@ namespace FSO.Client.UI.Panels
                 {
                     OnDelete(Holding, null);
                     ClearSelected();
+                } else if (state.KeyboardState.IsKeyDown(Keys.I))
+                {
+                    if (state.InputManager.GetFocus() == null)
+                    {
+                        MoveToInventory(null);
+                    }
                 }
             }
             if (Holding != null && Roommate)


### PR DESCRIPTION
Uses previously existing function which checks:
- Is your focus currently in another textbox? (Previous Deletion Commit Addition)
- Are you holding it?
- Do you own it?
- Can you delete it?

Tested in Sandbox, works well !