### PR TITLE
[API] Added funtionality and efficiency

### DIFF
--- a/TSOClient/FSO.Server.Api.Core/Controllers/UserOAuthController.cs
+++ b/TSOClient/FSO.Server.Api.Core/Controllers/UserOAuthController.cs
@@ -1,0 +1,128 @@
+﻿using FSO.Server.Api.Core.Utils;
+using FSO.Server.Common;
+using FSO.Server.Servers.Api.JsonWebToken;
+using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Web;
+using System.Web.Http;
+
+namespace FSO.Server.Api.Core.Controllers
+{
+    [Route("userapi/oauth/token")]
+    [ApiController]
+    public class UserOAuthController : ControllerBase
+    {
+        [HttpPost]
+        public IActionResult CreateToken([FromForm] UserOAuthRequest userAuthRequest)
+        {
+            if (userAuthRequest == null) BadRequest();
+            var api = Api.INSTANCE;
+            using (var da = api.DAFactory.Get())
+            {
+                var user = da.Users.GetByUsername(userAuthRequest.username);
+                if (user == null || user.is_banned) return ApiResponse.Json(System.Net.HttpStatusCode.Unauthorized, new UserOAuthError("unauthorized_client", "user_credentials_invalid"));
+                var ip = ApiUtils.GetIP(Request);
+                var hashSettings = da.Users.GetAuthenticationSettings(user.user_id);
+                var isPasswordCorrect = PasswordHasher.Verify(userAuthRequest.password, new PasswordHash
+                {
+                    data = hashSettings.data,
+                    scheme = hashSettings.scheme_class
+                });
+                //check if account is locked due to failed attempts
+                var accLock = da.Users.GetRemainingAuth(user.user_id, ip);
+                if (accLock != null && (accLock.active || accLock.count >= AuthLoginController.LockAttempts) && accLock.expire_time > Epoch.Now)
+                {
+                    return ApiResponse.Json(System.Net.HttpStatusCode.OK, new UserOAuthError("unauthorized_client", "account_locked"));
+                }
+                //if the password is incorrect and check if user failed muli times and set a time out till next try.
+                if (!isPasswordCorrect)
+                {
+                    var durations = AuthLoginController.LockDuration;
+                    var failDelay = 60 * durations[Math.Min(durations.Length - 1, da.Users.FailedConsecutive(user.user_id, ip))];
+                    if (accLock == null)
+                    {
+                        da.Users.NewFailedAuth(user.user_id, ip, (uint)failDelay);
+                    }
+                    else
+                    {
+                        var remaining = da.Users.FailedAuth(accLock.attempt_id, (uint)failDelay, AuthLoginController.LockAttempts);
+                    }
+                    return ApiResponse.Json(System.Net.HttpStatusCode.OK, new UserOAuthError("unauthorized_client", "user_credentials_invalid"));
+                }
+
+                //user passed the password check, and now creates the claim/token
+                da.Users.SuccessfulAuth(user.user_id, ip);
+                var claims = new List<string>();
+
+                //set the permission level in the claim
+                switch (userAuthRequest.permission_level)
+                {
+                    case 1:
+                        claims.Add("userReadPermissions");
+                        break;
+                    case 2:
+                        claims.Add("userReadPermissions");
+                        claims.Add("userWritePermissions");
+                        break;
+                    case 3:
+                        claims.Add("userReadPermissions");
+                        claims.Add("userWritePermissions");
+                        claims.Add("userUpdatePermissions");
+                        break;
+                    case 4:
+                        claims.Add("userReadPermissions");
+                        claims.Add("userWritePermissions");
+                        claims.Add("userUpdatePermissions");
+                        claims.Add("userDeletePermissions");
+                        break;
+                    default:
+                        break;
+                }
+                
+                //set the user identity
+                JWTUser identity = new JWTUser
+                {
+                    UserID = user.user_id,
+                    UserName = user.username,
+                    Claims = claims
+                };
+
+                //generate the the tokenen and send it in a JSON format as response
+                var generatedToken = api.JWT.CreateToken(identity);
+                return ApiResponse.Json(System.Net.HttpStatusCode.OK, new UserOAuthSuccess
+                {
+                    access_token = generatedToken.Token,
+                    expires_in = generatedToken.ExpiresIn
+                });
+            }
+            
+        }
+    }
+    public class UserOAuthRequest
+    {
+        public int permission_level { get; set; }
+        public string username { get; set; }
+        public string password { get; set; }
+    }
+    public class UserOAuthError
+    {
+        public string error;
+        public string error_description;
+        public UserOAuthError(string errorString,string errorDescriptionString)
+        {
+            error = errorString;
+            error_description = errorDescriptionString;
+        }
+    }
+    public class UserOAuthSuccess
+    {
+        public string access_token { get; set; }
+        public int expires_in { get; set; }
+    }
+
+}

--- a/TSOClient/FSO.Server.Database/DA/AvatarClaims/IAvatarClaims.cs
+++ b/TSOClient/FSO.Server.Database/DA/AvatarClaims/IAvatarClaims.cs
@@ -11,6 +11,7 @@ namespace FSO.Server.Database.DA.AvatarClaims
         DbAvatarClaim Get(int id);
         IEnumerable<DbAvatarClaim> GetAll();
         IEnumerable<DbAvatarActive> GetAllActiveAvatars();
+        int? GetAllActiveAvatarsCount();
         DbAvatarClaim GetByAvatarID(uint id);
         IEnumerable<DbAvatarClaim> GetAllByOwner(string owner);
 

--- a/TSOClient/FSO.Server.Database/DA/AvatarClaims/SqlAvatarClaims.cs
+++ b/TSOClient/FSO.Server.Database/DA/AvatarClaims/SqlAvatarClaims.cs
@@ -57,6 +57,10 @@ namespace FSO.Server.Database.DA.AvatarClaims
             return Context.Connection.Query<DbAvatarActive>("SELECT b.*, a.location FROM fso.fso_avatar_claims as a "+
                 "inner join fso.fso_avatars as b ON a.avatar_id = b.avatar_id;");
         }
+        public int? GetAllActiveAvatarsCount()
+        {
+            return Context.Connection.Query<int>("SELECT COUNT(*) FROM fso_avatar_claims").FirstOrDefault();
+        }
         public DbAvatarClaim GetByAvatarID(uint id)
         {
             return Context.Connection.Query<DbAvatarClaim>("SELECT * FROM fso_avatar_claims WHERE avatar_id = @id", new { id = id }).FirstOrDefault();

--- a/TSOClient/FSO.Server.Database/DA/Avatars/IAvatars.cs
+++ b/TSOClient/FSO.Server.Database/DA/Avatars/IAvatars.cs
@@ -11,7 +11,7 @@ namespace FSO.Server.Database.DA.Avatars
         uint Create(DbAvatar avatar);
 
         DbAvatar Get(uint id);
-        
+        List<DbAvatar> GetMultiple(uint[] id);
         bool Delete(uint id);
         int GetPrivacyMode(uint id);
         int GetModerationLevel(uint id);

--- a/TSOClient/FSO.Server.Database/DA/Avatars/IAvatars.cs
+++ b/TSOClient/FSO.Server.Database/DA/Avatars/IAvatars.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using FSO.Server.Database.DA.Utils;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -18,6 +19,7 @@ namespace FSO.Server.Database.DA.Avatars
         DbJobLevel GetCurrentJobLevel(uint avatar_id);
         List<DbJobLevel> GetJobLevels(uint avatar_id);
         IEnumerable<DbAvatar> All(int shard_id);
+        PagedList<DbAvatar> AllByPage(int shard_id, int offset, int limit, string orderBy);
         List<uint> GetLivingInNhood(uint nhood_id);
         List<AvatarRating> GetPossibleCandidatesNhood(uint nhood_id);
 

--- a/TSOClient/FSO.Server.Database/DA/Avatars/SqlAvatars.cs
+++ b/TSOClient/FSO.Server.Database/DA/Avatars/SqlAvatars.cs
@@ -87,6 +87,21 @@ namespace FSO.Server.Database.DA.Avatars
             ).ToList();
         }
 
+        public List<DbAvatar> GetMultiple(uint[] id)
+        {
+            String inClause = "IN (";
+            for (int i = 0; i < id.Length; i++)
+            {
+                inClause = inClause + "'" + id.ElementAt(i) + "'" + ",";
+            }
+            inClause = inClause.Substring(0, inClause.Length - 1);
+            inClause = inClause + ")";
+
+            return Context.Connection.Query<DbAvatar>(
+                "Select * from fso_avatars Where avatar_id "+ inClause
+            ).ToList();
+        }
+
         public List<DbAvatar> SearchExact(int shard_id, string name, int limit)
         {
             return Context.Connection.Query<DbAvatar>(

--- a/TSOClient/FSO.Server.Database/DA/Avatars/SqlAvatars.cs
+++ b/TSOClient/FSO.Server.Database/DA/Avatars/SqlAvatars.cs
@@ -1,4 +1,5 @@
 ﻿using Dapper;
+using FSO.Server.Database.DA.Utils;
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
@@ -11,6 +12,12 @@ namespace FSO.Server.Database.DA.Avatars
     public class SqlAvatars : AbstractSqlDA, IAvatars
     {
         public SqlAvatars(ISqlContext context) : base(context){
+        }
+        public PagedList<DbAvatar> AllByPage(int shard_id,int offset = 1, int limit = 100, string orderBy = "avatar_id")
+        {
+            var total = Context.Connection.Query<int>("SELECT COUNT(*) FROM fso_avatars WHERE shard_id = @shard_id",new { shard_id = shard_id }).FirstOrDefault();
+            var results = Context.Connection.Query<DbAvatar>("SELECT * FROM fso_avatars WHERE shard_id = @shard_id ORDER BY @order DESC LIMIT @offset, @limit", new { shard_id = shard_id, order = orderBy, offset = offset, limit = limit });
+            return new PagedList<DbAvatar>(results, offset, total);
         }
 
         public IEnumerable<DbAvatar> All(int shard_id){

--- a/TSOClient/FSO.Server.Database/DA/LotClaims/DbLotClaim.cs
+++ b/TSOClient/FSO.Server.Database/DA/LotClaims/DbLotClaim.cs
@@ -28,6 +28,7 @@ namespace FSO.Server.Database.DA.LotClaims
         public string description { get; set; }
         public uint location { get; set; }
         public uint neighborhood_id { get; set; }
+        public uint admit_mode { get; set; }
         public FSO.Common.Enum.LotCategory category { get; set; }
         public int active { get; set; }
     }

--- a/TSOClient/FSO.Server.Database/DA/Lots/ILots.cs
+++ b/TSOClient/FSO.Server.Database/DA/Lots/ILots.cs
@@ -18,6 +18,7 @@ namespace FSO.Server.Database.DA.Lots
         List<DbLot> GetAdjToLocation(int shard_id, uint location);
         DbLot GetByOwner(uint owner_id);
         DbLot Get(int id);
+        List<DbLot> GetMultiple(int[] ids);
         List<DbLot> Get(IEnumerable<int> ids);
         uint Create(DbLot lot);
         bool Delete(int id);

--- a/TSOClient/FSO.Server.Database/DA/Lots/ILots.cs
+++ b/TSOClient/FSO.Server.Database/DA/Lots/ILots.cs
@@ -1,4 +1,5 @@
 ﻿using FSO.Common.Enum;
+using FSO.Server.Database.DA.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +11,7 @@ namespace FSO.Server.Database.DA.Lots
     public interface ILots
     {
         IEnumerable<DbLot> All(int shard_id);
+        PagedList<DbLot> AllByPage(int shard_id, int offset, int limit, string orderBy);
         List<uint> GetLocationsInNhood(uint nhood_id);
         List<uint> GetCommunityLocations(int shard_id);
         List<DbLot> AllLocations(int shard_id);

--- a/TSOClient/FSO.Server.Database/DA/Lots/SqlLots.cs
+++ b/TSOClient/FSO.Server.Database/DA/Lots/SqlLots.cs
@@ -20,6 +20,20 @@ namespace FSO.Server.Database.DA.Lots
         public DbLot Get(int id){
             return Context.Connection.Query<DbLot>("SELECT * FROM fso_lots WHERE lot_id = @id", new { id = id }).FirstOrDefault();
         }
+        public List<DbLot> GetMultiple(int[] id)
+        {
+            String inClause = "IN (";
+            for (int i = 0; i < id.Length; i++)
+            {
+                inClause = inClause + "'" + id.ElementAt(i) + "'" + ",";
+            }
+            inClause = inClause.Substring(0, inClause.Length - 1);
+            inClause = inClause + ")";
+
+            return Context.Connection.Query<DbLot>(
+                "SELECT * FROM fso_lots WHERE lot_id " + inClause
+            ).ToList();
+        }
 
         public List<DbLot> Get(IEnumerable<int> ids)
         {
@@ -128,7 +142,7 @@ namespace FSO.Server.Database.DA.Lots
         {
             return Context.Connection.Query<DbLot>("SELECT * FROM fso_lots WHERE location = @location AND shard_id = @shard_id", new { location = location, shard_id = shard_id }).FirstOrDefault();
         }
-
+ 
         public List<DbLot> GetAdjToLocation(int shard_id, uint location)
         {
             return Context.Connection.Query<DbLot>("SELECT * FROM fso_lots WHERE "

--- a/TSOClient/FSO.Server.Database/DA/Lots/SqlLots.cs
+++ b/TSOClient/FSO.Server.Database/DA/Lots/SqlLots.cs
@@ -3,6 +3,7 @@ using FSO.Common.Enum;
 using FSO.Server.Common;
 using FSO.Server.Database.DA.Roommates;
 using FSO.Server.Database.DA.Shards;
+using FSO.Server.Database.DA.Utils;
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
@@ -111,6 +112,12 @@ namespace FSO.Server.Database.DA.Lots
         public IEnumerable<DbLot> All(int shard_id)
         {
             return Context.Connection.Query<DbLot>("SELECT * FROM fso_lots WHERE shard_id = @shard_id", new { shard_id = shard_id });
+        }
+        public PagedList<DbLot> AllByPage(int shard_id, int offset = 1, int limit = 100, string orderBy = "lot_id")
+        {
+            var total = Context.Connection.Query<int>("SELECT COUNT(*) FROM fso_lots WHERE shard_id = @shard_id", new { shard_id = shard_id }).FirstOrDefault();
+            var results = Context.Connection.Query<DbLot>("SELECT * FROM fso_lots WHERE shard_id = @shard_id ORDER BY @order DESC LIMIT @offset, @limit", new { shard_id = shard_id, order = orderBy, offset = offset, limit = limit });
+            return new PagedList<DbLot>(results, offset, total);
         }
 
         public List<DbLot> AllLocations(int shard_id)


### PR DESCRIPTION
- userOauth token (with specified permissions)
- avatarinfo
  get avatars from specific user (req user auth)
  get avatars from multiple ids
  get all avatars now can get up to 500 avatars per page
  getting all neighborhood avatars is more efficient
  online avatars can also be requested as compact now (only online count)
- lotinfo
  json objects now include lot_id (more consistent/reliable value than location)
  json objects now include admit_mode
  get lots from multiple ids
  online lots can also be requested as compact now (only online count)
  added funtion for getting all the lots by pages, and max 500 lots per page