### PR TITLE
No out-of-window keys capturing, AltGr ≠ Ctrl (continued)

### DIFF
--- a/TSOClient/tso.client/UI/Panels/UILotControl.cs
+++ b/TSOClient/tso.client/UI/Panels/UILotControl.cs
@@ -990,12 +990,10 @@ namespace FSO.Client.UI.Panels
                 }
                 var nofocus = state.InputManager.GetFocus() == null;
                 var keyst = state.KeyboardState;
-                if (nofocus && (keyst.IsKeyDown(Keys.Up) || keyst.IsKeyDown(Keys.Left) || keyst.IsKeyDown(Keys.Down) || keyst.IsKeyDown(Keys.Right) ||
-                    (keyst.IsKeyDown(Keys.W) || keyst.IsKeyDown(Keys.A) || keyst.IsKeyDown(Keys.S) || keyst.IsKeyDown(Keys.D))))
-                    KBScroll = true;
-                else
-                    KBScroll = false;
-                    if (MouseIsOn)
+                KBScroll = state.WindowFocused && nofocus &&
+                    (keyst.IsKeyDown(Keys.Up) || keyst.IsKeyDown(Keys.Left) || keyst.IsKeyDown(Keys.Down) || keyst.IsKeyDown(Keys.Right) ||
+                    keyst.IsKeyDown(Keys.W) || keyst.IsKeyDown(Keys.A) || keyst.IsKeyDown(Keys.S) || keyst.IsKeyDown(Keys.D));
+                if (MouseIsOn)
                 {
                     if (state.MouseState.RightButton == ButtonState.Pressed)
                     {
@@ -1028,16 +1026,18 @@ namespace FSO.Client.UI.Panels
 
                 //set cutaway around mouse
                 UpdateCutaway(state);
-
-                if (state.NewKeys.Contains(Keys.S) && state.KeyboardState.IsKeyDown(Keys.LeftControl))
+                if(state.WindowFocused && nofocus)
                 {
-                    //save lot
-                    if (LotSaveDialog == null) SaveLot();
-                }
-                else if (state.NewKeys.Contains(Keys.F) && state.KeyboardState.IsKeyDown(Keys.LeftControl))
-                {
-                    //save facade
-                    if (LotSaveDialog == null) SaveFacade(state.KeyboardState.IsKeyDown(Keys.LeftAlt));
+                    if (state.NewKeys.Contains(Keys.S) && state.KeyboardState.IsKeyDown(Keys.LeftControl) && !state.KeyboardState.IsKeyDown(Keys.RightAlt))
+                    {
+                        //save lot
+                        if (LotSaveDialog == null) SaveLot();
+                    }
+                    else if (state.NewKeys.Contains(Keys.F) && state.KeyboardState.IsKeyDown(Keys.LeftControl) && !state.KeyboardState.IsKeyDown(Keys.RightAlt))
+                    {
+                        //save facade
+                        if (LotSaveDialog == null) SaveFacade(state.KeyboardState.IsKeyDown(Keys.LeftAlt));
+                    }
                 }
             }
         }

--- a/TSOClient/tso.client/UI/Panels/UIObjectHolder.cs
+++ b/TSOClient/tso.client/UI/Panels/UIObjectHolder.cs
@@ -472,28 +472,26 @@ namespace FSO.Client.UI.Panels
             if (Locked) return;
 
             CursorType cur = CursorType.SimsMove;
-            if (Holding != null)
+            if (Holding != null && state.WindowFocused)
             {
-                if (Roommate) cur = CursorType.SimsPlace;
-                if (state.KeyboardState.IsKeyDown(Keys.Delete))
-                {
-                    if (state.InputManager.GetFocus() == null)
-                    {
-                        SellBack(null);
-                    }
-                } else if (state.KeyboardState.IsKeyDown(Keys.Escape))
+                if (state.KeyboardState.IsKeyDown(Keys.Escape))
                 {
                     OnDelete(Holding, null);
                     ClearSelected();
-                } else if (state.KeyboardState.IsKeyDown(Keys.I))
+                } else if (state.InputManager.GetFocus() == null)
                 {
-                    if (state.InputManager.GetFocus() == null)
+                    if (state.KeyboardState.IsKeyDown(Keys.I))
                     {
                         MoveToInventory(null);
+                    } else if (state.KeyboardState.IsKeyDown(Keys.Delete))
+                    {
+                        SellBack(null);
                     }
                 }
             }
             if (Holding != null && Roommate)
+            {
+                cur = CursorType.SimsPlace;
             {
                 if (MouseClicked) Holding.Clicked = true;
                 if (MouseIsDown && Holding.Clicked)

--- a/TSOClient/tso.client/UI/Panels/UIUCP.cs
+++ b/TSOClient/tso.client/UI/Panels/UIUCP.cs
@@ -439,7 +439,7 @@ namespace FSO.Client.UI.Panels
             var keys = state.NewKeys;
             var nofocus = state.InputManager.GetFocus() == null;
             base.Update(state);
-            if (Game.InLot)
+            if (Game.InLot && state.WindowFocused)
             {
                 if (keys.Contains(Keys.F1) && !state.CtrlDown) SetPanel(1); // Live Mode Panel
                 if (keys.Contains(Keys.F2)) SetPanel(2); // Buy Mode Panel

--- a/TSOClient/tso.client/UI/Screens/SandboxGameScreen.cs
+++ b/TSOClient/tso.client/UI/Screens/SandboxGameScreen.cs
@@ -285,14 +285,18 @@ namespace FSO.Client.UI.Screens
             Visible = World?.Visible == true && (World?.State as FSO.LotView.RC.WorldStateRC)?.CameraMode != true;
             GameFacade.Game.IsMouseVisible = Visible;
 
-            if (state.NewKeys.Contains(Microsoft.Xna.Framework.Input.Keys.F1) && state.CtrlDown)
+            if (state.WindowFocused && state.NewKeys.Contains(Microsoft.Xna.Framework.Input.Keys.F1) && state.CtrlDown)
                 FSOFacade.Controller.ToggleDebugMenu();
 
             base.Update(state);
-            if (state.NewKeys.Contains(Keys.D1)) ChangeSpeedTo(1);
-            if (state.NewKeys.Contains(Keys.D2)) ChangeSpeedTo(2);
-            if (state.NewKeys.Contains(Keys.D3)) ChangeSpeedTo(3);
-            if (state.NewKeys.Contains(Keys.P)) ChangeSpeedTo(0);
+            
+            if (state.WindowFocused && state.InputManager.GetFocus() == null)
+            {
+                if (state.NewKeys.Contains(Keys.D1) || (state.KeyboardState.NumLock && state.NewKeys.Contains(Keys.NumPad1))) ChangeSpeedTo(1);
+                else if (state.NewKeys.Contains(Keys.D2) || (state.KeyboardState.NumLock && state.NewKeys.Contains(Keys.NumPad2))) ChangeSpeedTo(2);
+                else if (state.NewKeys.Contains(Keys.D3) || (state.KeyboardState.NumLock && state.NewKeys.Contains(Keys.NumPad3))) ChangeSpeedTo(3);
+                else if (state.NewKeys.Contains(Keys.P) || state.NewKeys.Contains(Keys.D0) || (state.KeyboardState.NumLock && state.NewKeys.Contains(Keys.NumPad0))) ChangeSpeedTo(0);
+            }
 
             if (World != null)
             { 

--- a/TSOClient/tso.common/rendering/framework/io/InputManager.cs
+++ b/TSOClient/tso.common/rendering/framework/io/InputManager.cs
@@ -54,6 +54,8 @@ namespace FSO.Common.Rendering.Framework.IO
         /// <param name="keys"></param>
         public KeyboardInputResult ApplyKeyboardInput(StringBuilder m_SBuilder, UpdateState state, int cursorIndex, int cursorEndIndex, bool allowInput)
         {
+            if (state.WindowFocused) { return null; }
+            
             var PressedKeys = state.KeyboardState.GetPressedKeys();
             int charCount = 0;
             if (state.FrameTextInput == null) charCount = 0;

--- a/TSOClient/tso.common/rendering/framework/io/InputManager.cs
+++ b/TSOClient/tso.common/rendering/framework/io/InputManager.cs
@@ -54,7 +54,7 @@ namespace FSO.Common.Rendering.Framework.IO
         /// <param name="keys"></param>
         public KeyboardInputResult ApplyKeyboardInput(StringBuilder m_SBuilder, UpdateState state, int cursorIndex, int cursorEndIndex, bool allowInput)
         {
-            if (state.WindowFocused) { return null; }
+            if (!state.WindowFocused) { return null; }
             
             var PressedKeys = state.KeyboardState.GetPressedKeys();
             int charCount = 0;

--- a/TSOClient/tso.common/rendering/framework/model/UpdateState.cs
+++ b/TSOClient/tso.common/rendering/framework/model/UpdateState.cs
@@ -39,9 +39,13 @@ namespace FSO.Common.Rendering.Framework.Model
         {
             get { return KeyboardState.IsKeyDown(Keys.LeftShift) || KeyboardState.IsKeyDown(Keys.RightShift); }
         }
+        /// <summary>
+        /// Right alt is treated as LeftCtrl+RightAlt so while right Alt is down, you cannot predict if left Ctrl is also down.
+        /// For that reason, this variable is false when left Ctrl and right Alt are down, and right Ctrl is not down.
+        /// </summary>
         public bool CtrlDown
         {
-            get { return KeyboardState.IsKeyDown(Keys.LeftControl) || KeyboardState.IsKeyDown(Keys.RightControl); }
+            get { return (KeyboardState.IsKeyDown(Keys.LeftControl) && !KeyboardState.IsKeyDown(Keys.RightAlt)) || KeyboardState.IsKeyDown(Keys.RightControl); }
         }
         public bool AltDown
         {


### PR DESCRIPTION
The game should no longer capture keyboard keys while the window is out of focus. A lot/facade cannot be saved while an input is in focus.
AltGr is no longer treated as Ctrl… but, unfortunately, Ctrl isn't detected in `AltGr`+`LeftCtrl`. It's a makeshift solution, like #156.