### PR TITLE
Admin Red Chat Balloon

### DIFF
--- a/TSOClient/tso.client/UI/Panels/UIChatBalloon.cs
+++ b/TSOClient/tso.client/UI/Panels/UIChatBalloon.cs
@@ -32,7 +32,7 @@ namespace FSO.Client.UI.Panels
         private UIChatPanel Owner;
 
         public Color Color;
-        private Color BgColor = new Color(8, 8, 128); // default balloon color
+        private Color BgColor = new Color(8,8,128); // default balloon color
 
         public string Name;
         public string Message;
@@ -89,10 +89,10 @@ namespace FSO.Client.UI.Panels
             Gender = avatar.GetPersonData(SimAntics.Model.VMPersonDataVariable.Gender) > 0;
             TTSContext?.Speak(Message.Replace('_', ' '), Gender, ((VMTSOAvatarState)avatar.TSOState).ChatTTSPitch);
 
-            if (((VMTSOAvatarState)avatar.TSOState).Permissions == VMTSOAvatarPermissions.Admin)
-                BgColor = Color.Red; // admin red color
+            if (((VMTSOAvatarState)avatar.TSOState).Permissions == VMTSOAvatarPermissions.Admin)            
+                BgColor = Color.Red; // admin red color            
             else
-                BgColor = new Color(8, 8, 128); // default color
+                BgColor = new Color(8, 8, 128); // default blue color            
             Offscreen = false;
             if (Message == "") Name = "";
             TextChanged();
@@ -112,7 +112,7 @@ namespace FSO.Client.UI.Panels
             }
             BodyText = ((Offscreen && Message != "") ? "\\[" + Name + "] " : "") + GameFacade.Emojis.EmojiToBB(SanitizeBB(BodyText));
 
-            var textW = Math.Max(130, Message.Length * 2);
+            var textW = Math.Max(130, Message.Length*2);
             BodyTextLabels = TextRenderer.ComputeText(BodyText, new TextRendererOptions
             {
                 BBCode = true,
@@ -160,7 +160,7 @@ namespace FSO.Client.UI.Panels
         public void UpdateDesiredPosition()
         {
             DesiredRectPos = new Point((int)(TargetPt.X - DisplayRect.Width / 2), (int)(TargetPt.Y - (DisplayRect.Height + 20)));
-            var dr = new Rectangle(DesiredRectPos, new Point(DisplayRect.Width, DisplayRect.Height));
+            var dr = new Rectangle(DesiredRectPos, new Point(DisplayRect.Width, DisplayRect.Height)); 
 
             bool changed = false;
             foreach (var area in Owner.GetInvalid(this))
@@ -175,12 +175,11 @@ namespace FSO.Client.UI.Panels
                     if (Math.Abs(xDist) > Math.Abs(yDist))
                     {
                         if (xDist < 0) dr.X = area.Right;
-                        else dr.X = area.Left - dr.Width;
-                    }
-                    else
+                        else dr.X = area.Left-dr.Width;
+                    } else
                     {
                         if (yDist < 0) dr.Y = area.Bottom;
-                        else dr.Y = area.Top - dr.Height;
+                        else dr.Y = area.Top-dr.Height;
                     }
                     changed = true;
                 }
@@ -239,10 +238,10 @@ namespace FSO.Client.UI.Panels
             if (Alpha == 0) return;
             base.Draw(batch);
             Color bgCol = BgColor * Alpha;
-
+            
             //draw corners
-            DrawLocalTexture(batch, BTiles, new Rectangle(0, 0, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top - 20), Vector2.One, bgCol);
-            DrawLocalTexture(batch, BTiles, new Rectangle(40, 0, 40, 40), new Vector2(DisplayRect.Right + 20, DisplayRect.Top - 20), new Vector2(-1, 1), bgCol);
+            DrawLocalTexture(batch, BTiles, new Rectangle(0, 0, 40, 40), new Vector2(DisplayRect.Left-20, DisplayRect.Top-20), Vector2.One, bgCol);
+            DrawLocalTexture(batch, BTiles, new Rectangle(40, 0, 40, 40), new Vector2(DisplayRect.Right + 20, DisplayRect.Top - 20), new Vector2(-1,1), bgCol);
             DrawLocalTexture(batch, BTiles, new Rectangle(80, 0, 40, 40), new Vector2(DisplayRect.Right + 20, DisplayRect.Bottom + 20), new Vector2(-1, -1), bgCol);
             DrawLocalTexture(batch, BTiles, new Rectangle(120, 0, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Bottom + 20), new Vector2(1, -1), bgCol);
 
@@ -250,10 +249,10 @@ namespace FSO.Client.UI.Panels
             //if the pointer is on this edge, it needs to be split into 3... Before point, point and after point. 
 
             var vertH = DisplayRect.Height - 40;
-            var vertPt = Math.Max(DisplayRect.Top + 20, Math.Min(DisplayRect.Bottom - 60, TargetPt.Y - 20)) - (DisplayRect.Top + 20);
+            var vertPt = (int)Math.Max(DisplayRect.Top + 20, Math.Min(DisplayRect.Bottom - 60, TargetPt.Y-20)) - (DisplayRect.Top + 20);
 
             var horizW = DisplayRect.Width - 40;
-            var horizPt = Math.Max(DisplayRect.Left + 20, Math.Min(DisplayRect.Right - 60, TargetPt.X - 20)) - (DisplayRect.Left + 20);
+            var horizPt = (int)Math.Max(DisplayRect.Left + 20, Math.Min(DisplayRect.Right - 60, TargetPt.X-20)) - (DisplayRect.Left + 20);
 
             int ptSel = 0;
 
@@ -263,9 +262,9 @@ namespace FSO.Client.UI.Panels
                 ptSel = Math.Max(0, Math.Min(3, (int)Math.Floor((DisplayRect.Left - TargetPt.X) / 40f)));
                 DrawLocalTexture(batch, BTiles, new Rectangle(0, 40, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top + 20), new Vector2(1, vertPt / 40f), bgCol);
                 DrawLocalTexture(batch, BPointerSide, new Rectangle(0, ptSel * 40, 200, 40), new Vector2(DisplayRect.Left - 180, DisplayRect.Top + 20 + vertPt), Vector2.One, bgCol);
-                DrawLocalTexture(batch, BTiles, new Rectangle(0, 40, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top + 60 + vertPt), new Vector2(1, (vertH - (vertPt + 40)) / 40f), bgCol);
+                DrawLocalTexture(batch, BTiles, new Rectangle(0, 40, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top + 60 + vertPt), new Vector2(1, (vertH-(vertPt+40)) / 40f), bgCol);
             }
-            else DrawLocalTexture(batch, BTiles, new Rectangle(0, 40, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top + 20), new Vector2(1, (DisplayRect.Height - 40) / 40f), bgCol);
+            else DrawLocalTexture(batch, BTiles, new Rectangle(0, 40, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top + 20), new Vector2(1, (DisplayRect.Height-40)/40f), bgCol);
 
             //top
             if (ClosestDir == 1)
@@ -298,10 +297,10 @@ namespace FSO.Client.UI.Panels
             else DrawLocalTexture(batch, BTiles, new Rectangle(0, 120, 40, 40), new Vector2(DisplayRect.Left + 20, DisplayRect.Bottom - 20), new Vector2((DisplayRect.Width - 40) / 40f, 1), bgCol);
 
             //draw middle
-            DrawLocalTexture(batch, BTiles, new Rectangle(40, 120, 1, 1), new Vector2(DisplayRect.Left + 20, DisplayRect.Top + 20), new Vector2(DisplayRect.Width - 40, DisplayRect.Height - 40), bgCol);
+            DrawLocalTexture(batch, BTiles, new Rectangle(40, 120, 1, 1), new Vector2(DisplayRect.Left + 20, DisplayRect.Top + 20), new Vector2(DisplayRect.Width-40, DisplayRect.Height-40), bgCol);
 
-
-            Vector2 offpos = new Vector2(DisplayRect.X + 1, DisplayRect.Y + 1) * Scale;
+            
+            Vector2 offpos = new Vector2(DisplayRect.X + 1, DisplayRect.Y + 1)*Scale;
             int posi = 0;
             foreach (var cmd in BodyTextLabels.DrawingCommands)
             {
@@ -320,8 +319,7 @@ namespace FSO.Client.UI.Panels
             offpos = new Vector2(DisplayRect.X, DisplayRect.Y) * Scale;
             foreach (var cmd in BodyTextLabels.DrawingCommands)
             {
-                if (cmd is INormalTextCmd)
-                {
+                if (cmd is INormalTextCmd) {
                     ((INormalTextCmd)cmd).Style = BodyTextStyle;
                     ((INormalTextCmd)cmd).Position = BTOffsets[posi++] + offpos;
                 }

--- a/TSOClient/tso.client/UI/Panels/UIChatBalloon.cs
+++ b/TSOClient/tso.client/UI/Panels/UIChatBalloon.cs
@@ -32,6 +32,7 @@ namespace FSO.Client.UI.Panels
         private UIChatPanel Owner;
 
         public Color Color;
+        private Color BgColor = new Color(8, 8, 128); // default balloon color
 
         public string Name;
         public string Message;
@@ -87,7 +88,11 @@ namespace FSO.Client.UI.Panels
             Message = avatar.Message;
             Gender = avatar.GetPersonData(SimAntics.Model.VMPersonDataVariable.Gender) > 0;
             TTSContext?.Speak(Message.Replace('_', ' '), Gender, ((VMTSOAvatarState)avatar.TSOState).ChatTTSPitch);
-            
+
+            if (((VMTSOAvatarState)avatar.TSOState).Permissions == VMTSOAvatarPermissions.Admin)
+                BgColor = Color.Red; // admin red color
+            else
+                BgColor = new Color(8, 8, 128); // default color
             Offscreen = false;
             if (Message == "") Name = "";
             TextChanged();
@@ -107,7 +112,7 @@ namespace FSO.Client.UI.Panels
             }
             BodyText = ((Offscreen && Message != "") ? "\\[" + Name + "] " : "") + GameFacade.Emojis.EmojiToBB(SanitizeBB(BodyText));
 
-            var textW = Math.Max(130, Message.Length*2);
+            var textW = Math.Max(130, Message.Length * 2);
             BodyTextLabels = TextRenderer.ComputeText(BodyText, new TextRendererOptions
             {
                 BBCode = true,
@@ -155,7 +160,7 @@ namespace FSO.Client.UI.Panels
         public void UpdateDesiredPosition()
         {
             DesiredRectPos = new Point((int)(TargetPt.X - DisplayRect.Width / 2), (int)(TargetPt.Y - (DisplayRect.Height + 20)));
-            var dr = new Rectangle(DesiredRectPos, new Point(DisplayRect.Width, DisplayRect.Height)); 
+            var dr = new Rectangle(DesiredRectPos, new Point(DisplayRect.Width, DisplayRect.Height));
 
             bool changed = false;
             foreach (var area in Owner.GetInvalid(this))
@@ -170,11 +175,12 @@ namespace FSO.Client.UI.Panels
                     if (Math.Abs(xDist) > Math.Abs(yDist))
                     {
                         if (xDist < 0) dr.X = area.Right;
-                        else dr.X = area.Left-dr.Width;
-                    } else
+                        else dr.X = area.Left - dr.Width;
+                    }
+                    else
                     {
                         if (yDist < 0) dr.Y = area.Bottom;
-                        else dr.Y = area.Top-dr.Height;
+                        else dr.Y = area.Top - dr.Height;
                     }
                     changed = true;
                 }
@@ -232,11 +238,11 @@ namespace FSO.Client.UI.Panels
         {
             if (Alpha == 0) return;
             base.Draw(batch);
-            Color bgCol = new Color(8,8,128) * Alpha;
-            
+            Color bgCol = BgColor * Alpha;
+
             //draw corners
-            DrawLocalTexture(batch, BTiles, new Rectangle(0, 0, 40, 40), new Vector2(DisplayRect.Left-20, DisplayRect.Top-20), Vector2.One, bgCol);
-            DrawLocalTexture(batch, BTiles, new Rectangle(40, 0, 40, 40), new Vector2(DisplayRect.Right + 20, DisplayRect.Top - 20), new Vector2(-1,1), bgCol);
+            DrawLocalTexture(batch, BTiles, new Rectangle(0, 0, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top - 20), Vector2.One, bgCol);
+            DrawLocalTexture(batch, BTiles, new Rectangle(40, 0, 40, 40), new Vector2(DisplayRect.Right + 20, DisplayRect.Top - 20), new Vector2(-1, 1), bgCol);
             DrawLocalTexture(batch, BTiles, new Rectangle(80, 0, 40, 40), new Vector2(DisplayRect.Right + 20, DisplayRect.Bottom + 20), new Vector2(-1, -1), bgCol);
             DrawLocalTexture(batch, BTiles, new Rectangle(120, 0, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Bottom + 20), new Vector2(1, -1), bgCol);
 
@@ -244,10 +250,10 @@ namespace FSO.Client.UI.Panels
             //if the pointer is on this edge, it needs to be split into 3... Before point, point and after point. 
 
             var vertH = DisplayRect.Height - 40;
-            var vertPt = Math.Max(DisplayRect.Top + 20, Math.Min(DisplayRect.Bottom - 60, TargetPt.Y-20)) - (DisplayRect.Top + 20);
+            var vertPt = Math.Max(DisplayRect.Top + 20, Math.Min(DisplayRect.Bottom - 60, TargetPt.Y - 20)) - (DisplayRect.Top + 20);
 
             var horizW = DisplayRect.Width - 40;
-            var horizPt = Math.Max(DisplayRect.Left + 20, Math.Min(DisplayRect.Right - 60, TargetPt.X-20)) - (DisplayRect.Left + 20);
+            var horizPt = Math.Max(DisplayRect.Left + 20, Math.Min(DisplayRect.Right - 60, TargetPt.X - 20)) - (DisplayRect.Left + 20);
 
             int ptSel = 0;
 
@@ -257,9 +263,9 @@ namespace FSO.Client.UI.Panels
                 ptSel = Math.Max(0, Math.Min(3, (int)Math.Floor((DisplayRect.Left - TargetPt.X) / 40f)));
                 DrawLocalTexture(batch, BTiles, new Rectangle(0, 40, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top + 20), new Vector2(1, vertPt / 40f), bgCol);
                 DrawLocalTexture(batch, BPointerSide, new Rectangle(0, ptSel * 40, 200, 40), new Vector2(DisplayRect.Left - 180, DisplayRect.Top + 20 + vertPt), Vector2.One, bgCol);
-                DrawLocalTexture(batch, BTiles, new Rectangle(0, 40, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top + 60 + vertPt), new Vector2(1, (vertH-(vertPt+40)) / 40f), bgCol);
+                DrawLocalTexture(batch, BTiles, new Rectangle(0, 40, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top + 60 + vertPt), new Vector2(1, (vertH - (vertPt + 40)) / 40f), bgCol);
             }
-            else DrawLocalTexture(batch, BTiles, new Rectangle(0, 40, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top + 20), new Vector2(1, (DisplayRect.Height-40)/40f), bgCol);
+            else DrawLocalTexture(batch, BTiles, new Rectangle(0, 40, 40, 40), new Vector2(DisplayRect.Left - 20, DisplayRect.Top + 20), new Vector2(1, (DisplayRect.Height - 40) / 40f), bgCol);
 
             //top
             if (ClosestDir == 1)
@@ -292,10 +298,10 @@ namespace FSO.Client.UI.Panels
             else DrawLocalTexture(batch, BTiles, new Rectangle(0, 120, 40, 40), new Vector2(DisplayRect.Left + 20, DisplayRect.Bottom - 20), new Vector2((DisplayRect.Width - 40) / 40f, 1), bgCol);
 
             //draw middle
-            DrawLocalTexture(batch, BTiles, new Rectangle(40, 120, 1, 1), new Vector2(DisplayRect.Left + 20, DisplayRect.Top + 20), new Vector2(DisplayRect.Width-40, DisplayRect.Height-40), bgCol);
+            DrawLocalTexture(batch, BTiles, new Rectangle(40, 120, 1, 1), new Vector2(DisplayRect.Left + 20, DisplayRect.Top + 20), new Vector2(DisplayRect.Width - 40, DisplayRect.Height - 40), bgCol);
 
-            
-            Vector2 offpos = new Vector2(DisplayRect.X + 1, DisplayRect.Y + 1)*Scale;
+
+            Vector2 offpos = new Vector2(DisplayRect.X + 1, DisplayRect.Y + 1) * Scale;
             int posi = 0;
             foreach (var cmd in BodyTextLabels.DrawingCommands)
             {
@@ -314,7 +320,8 @@ namespace FSO.Client.UI.Panels
             offpos = new Vector2(DisplayRect.X, DisplayRect.Y) * Scale;
             foreach (var cmd in BodyTextLabels.DrawingCommands)
             {
-                if (cmd is INormalTextCmd) {
+                if (cmd is INormalTextCmd)
+                {
                     ((INormalTextCmd)cmd).Style = BodyTextStyle;
                     ((INormalTextCmd)cmd).Position = BTOffsets[posi++] + offpos;
                 }

--- a/TSOClient/tso.client/UI/Panels/UIChatBalloon.cs
+++ b/TSOClient/tso.client/UI/Panels/UIChatBalloon.cs
@@ -90,7 +90,7 @@ namespace FSO.Client.UI.Panels
             TTSContext?.Speak(Message.Replace('_', ' '), Gender, ((VMTSOAvatarState)avatar.TSOState).ChatTTSPitch);
 
             if (((VMTSOAvatarState)avatar.TSOState).Permissions == VMTSOAvatarPermissions.Admin)            
-                BgColor = Color.Red; // admin red color            
+                BgColor = new Color(193, 31, 30); // admin red color            
             else
                 BgColor = new Color(8, 8, 128); // default blue color            
             Offscreen = false;

--- a/TSOClient/tso.client/UI/Panels/UIChatBalloon.cs
+++ b/TSOClient/tso.client/UI/Panels/UIChatBalloon.cs
@@ -90,7 +90,7 @@ namespace FSO.Client.UI.Panels
             TTSContext?.Speak(Message.Replace('_', ' '), Gender, ((VMTSOAvatarState)avatar.TSOState).ChatTTSPitch);
 
             if (((VMTSOAvatarState)avatar.TSOState).Permissions == VMTSOAvatarPermissions.Admin)            
-                BgColor = new Color(193, 31, 30); // admin red color            
+                BgColor = new Color(180,0,0); // admin red color            
             else
                 BgColor = new Color(8, 8, 128); // default blue color            
             Offscreen = false;


### PR DESCRIPTION
This will make the UIChatBalloon for an admin/moderator sim appear red instead of blue to stand out among users. It checks if the avatar's TSOState permissions attribute is set to Admin when the balloon text is updated. To maintain user customization settings, this does not have an impact on the chat text color of the balloon, but white is the easiest color to read in my opinion.
