### PR TITLE
Refresh bookmarks panel everytime it shows

### DIFF
--- a/TSOClient/tso.client/Controllers/Panels/BookmarksController.cs
+++ b/TSOClient/tso.client/Controllers/Panels/BookmarksController.cs
@@ -95,6 +95,7 @@ namespace FSO.Client.Controllers.Panels
 
         public void Show()
         {
+            RefreshResults();
             View.Parent.Add(View);
             View.Visible = true;
         }


### PR DESCRIPTION
The bookmarks panel does not refresh states of bookmarked players as long as you don't click another tab. This is an attempt to fix that minor issue.