### PR TITLE
RackEOD: Bug fixes

### DIFF
--- a/TSOClient/tso.client/UI/Panels/EODs/UIRackEOD.cs
+++ b/TSOClient/tso.client/UI/Panels/EODs/UIRackEOD.cs
@@ -35,21 +35,34 @@ namespace FSO.Client.UI.Panels.EODs
 
         private void PurchaseErrorHandler(string name, byte[] type)
         {
-            // I already own this outfit
+            string title = GameFacade.Strings.GetString("264", "5"); // "Purchase Item"
+            String message = "";
+            // I already own this outfit - should do a custom error message but that means a new .cst entry...
             if (type[0] == 0)
             {
-
+                message = GameFacade.Strings.GetString("264", "10"); // "You have no more room in your Backpack"
             }
             else if (type[0] == 1)
             // I already own 5 outfits of this type
             {
-
+                message = GameFacade.Strings.GetString("264", "10"); // "You have no more room in your Backpack"
             }
-            // An unknown purchase error occured
+            // An unknown purchase error occured, probably not enough money suddenly
             else
             {
-
+                message = GameFacade.Strings.GetString("264", "9"); // "You can't afford that Item."
             }
+            UIAlert alert = null;
+            alert = UIScreen.GlobalShowAlert(new UIAlertOptions()
+            {
+                Title = title,
+                Message = message,
+                Buttons = UIAlertButton.Ok((btn) =>
+                {
+                    UIScreen.RemoveDialog(alert);
+                }),
+                Alignment = TextAlignment.Center
+            }, true);
         }
 
         private void BtnPurchase_OnButtonClick(Framework.UIElement button)

--- a/TSOClient/tso.client/UI/Panels/EODs/UIRackEOD.cs
+++ b/TSOClient/tso.client/UI/Panels/EODs/UIRackEOD.cs
@@ -27,6 +27,31 @@ namespace FSO.Client.UI.Panels.EODs
             btnPurchase.OnButtonClick += BtnPurchase_OnButtonClick;
         }
 
+        protected override void InitEOD()
+        {
+            base.InitEOD();
+            BinaryHandlers["rack_buy_error"] = PurchaseErrorHandler;
+        }
+
+        private void PurchaseErrorHandler(string name, byte[] type)
+        {
+            // I already own this outfit
+            if (type[0] == 0)
+            {
+
+            }
+            else if (type[0] == 1)
+            // I already own 5 outfits of this type
+            {
+
+            }
+            // An unknown purchase error occured
+            else
+            {
+
+            }
+        }
+
         private void BtnPurchase_OnButtonClick(Framework.UIElement button)
         {
             var selectedOutfit = GetSelectedOutfit();

--- a/TSOClient/tso.simantics/NetPlay/EODs/Handlers/VMEODRackPlugin.cs
+++ b/TSOClient/tso.simantics/NetPlay/EODs/Handlers/VMEODRackPlugin.cs
@@ -49,6 +49,15 @@ namespace FSO.SimAntics.NetPlay.EODs.Handlers
                 {
                     if(avatarOutfits.FirstOrDefault(x => x.asset_id == outfit.asset_id) != null){
                         //I already have this outfit
+                        client.Send("rack_buy_error", new byte[] { 0 });
+                        return;
+                    }
+
+                    var outfitsInCategory = avatarOutfits.Where(x => x.outfit_type == (byte)outfit.outfit_type).ToList();
+                    if (outfitsInCategory.Count >= 5)
+                    {
+                        // I already own 5 outfits of this type
+                        client.Send("rack_buy_error", new byte[] { 1 });
                         return;
                     }
 
@@ -73,6 +82,11 @@ namespace FSO.SimAntics.NetPlay.EODs.Handlers
 
                                     BroadcastOutfits(VM, true);
                                 });
+                        }
+                        else
+                        {
+                            // purchase failed, did I not have enough money?
+                            client.Send("rack_buy_error", new byte[] { 2 });
                         }
                     });
 


### PR DESCRIPTION
- When attempting to buy an outfit a Sim already owned, the transaction no longer silently fails _without_ charging the Sim's budget. An error message is displayed alerting the player.
- When attempting to buy an outfit in a category in which a Sim already owns 5 outfits, the transaction no longer silently fails _after_ charging a Sim's budget. An error message is displayed alerting the player and money is not deducted from the budget.

Rather than creating a new .cst entry for the "You cannot buy the same outfit twice" case, I just repeated the "You have no more room in your backpack" message.