### PR TITLE
Set to Next primitive operator "object with same semiglobal as"

### DIFF
--- a/TSOClient/FSO.IDE/EditorComponent/Primitives/SetToNextDescriptor.cs
+++ b/TSOClient/FSO.IDE/EditorComponent/Primitives/SetToNextDescriptor.cs
@@ -28,7 +28,7 @@ namespace FSO.IDE.EditorComponent.Primitives
             var nextObject = EditorScope.Behaviour.Get<STR>(164).GetString((int)op.SearchType);
             result.Append(nextObject);
 
-            if (op.SearchType == VMSetToNextSearchType.ObjectOfType) {
+            if (op.SearchType == VMSetToNextSearchType.ObjectOfType || op.SearchType == VMSetToNextSearchType.ObjectOfSemiGlobal) {
                 var obj = Content.Content.Get().WorldObjects.Get(op.GUID);
 
                 result.Append(" ");
@@ -52,7 +52,10 @@ namespace FSO.IDE.EditorComponent.Primitives
         public override void PopulateOperandView(BHAVEditor master, EditorScope escope, TableLayoutPanel panel)
         {
             panel.Controls.Add(new OpLabelControl(master, escope, Operand, new OpStaticTextProvider("Cycles the object with ID in the Target location to the next object of a specified type. Returns false when none or no more are available.")));
-            panel.Controls.Add(new OpComboControl(master, escope, Operand, "Search Type: ", "SearchType", new OpStaticNamedPropertyProvider(EditorScope.Behaviour.Get<STR>(164), 0)));
+            var types = new OpStaticNamedPropertyProvider(EditorScope.Behaviour.Get<STR>(164), 0);
+            types.EnsureProperty(13, "object under same semiglobal as");
+            panel.Controls.Add(new OpComboControl(master, escope, Operand, "Search Type:", "SearchType", types));
+
 
             panel.Controls.Add(new OpScopeControl(master, escope, Operand, "Target Scope: ", "TargetOwner", "TargetData"));
 

--- a/TSOClient/FSO.IDE/EditorComponent/Primitives/SetToNextDescriptor.cs
+++ b/TSOClient/FSO.IDE/EditorComponent/Primitives/SetToNextDescriptor.cs
@@ -53,7 +53,7 @@ namespace FSO.IDE.EditorComponent.Primitives
         {
             panel.Controls.Add(new OpLabelControl(master, escope, Operand, new OpStaticTextProvider("Cycles the object with ID in the Target location to the next object of a specified type. Returns false when none or no more are available.")));
             var types = new OpStaticNamedPropertyProvider(EditorScope.Behaviour.Get<STR>(164), 0);
-            types.EnsureProperty(13, "object under same semiglobal as");
+            types.EnsureProperty(13, "obj with same semiglobal as");
             panel.Controls.Add(new OpComboControl(master, escope, Operand, "Search Type:", "SearchType", types));
 
 

--- a/TSOClient/FSO.IDE/EditorComponent/Primitives/SetToNextDescriptor.cs
+++ b/TSOClient/FSO.IDE/EditorComponent/Primitives/SetToNextDescriptor.cs
@@ -28,7 +28,7 @@ namespace FSO.IDE.EditorComponent.Primitives
             var nextObject = EditorScope.Behaviour.Get<STR>(164).GetString((int)op.SearchType);
             result.Append(nextObject);
 
-            if (op.SearchType == VMSetToNextSearchType.ObjectOfType || op.SearchType == VMSetToNextSearchType.ObjectOfSemiGlobal) {
+            if (op.SearchType == VMSetToNextSearchType.ObjectOfType || op.SearchType == VMSetToNextSearchType.FSOObjectOfSemiGlobal) {
                 var obj = Content.Content.Get().WorldObjects.Get(op.GUID);
 
                 result.Append(" ");
@@ -53,7 +53,7 @@ namespace FSO.IDE.EditorComponent.Primitives
         {
             panel.Controls.Add(new OpLabelControl(master, escope, Operand, new OpStaticTextProvider("Cycles the object with ID in the Target location to the next object of a specified type. Returns false when none or no more are available.")));
             var types = new OpStaticNamedPropertyProvider(EditorScope.Behaviour.Get<STR>(164), 0);
-            types.EnsureProperty(13, "obj with same semiglobal as");
+            types.EnsureProperty(100, "obj with same semiglobal as");
             panel.Controls.Add(new OpComboControl(master, escope, Operand, "Search Type:", "SearchType", types));
 
 

--- a/TSOClient/FSO.SimAntics.JIT/Translation/CSharp/Primitives/CSSetToNextPrimitive.cs
+++ b/TSOClient/FSO.SimAntics.JIT/Translation/CSharp/Primitives/CSSetToNextPrimitive.cs
@@ -96,6 +96,10 @@ namespace FSO.SimAntics.JIT.Translation.CSharp.Primitives
                         csClass.UseParams = true;
                         codeResult.Add($"var entities = context.VM.Context.ObjectQueries.GetObjectsByCategory(args[0]);");
                         break;
+                    case VMSetToNextSearchType.ObjectOfSemiGlobal:
+                        codeResult.Add($"var semiglobal = FSO.Content.Content.Get().WorldObjects.Get(operand.GUID).Resource.SemiGlobal;");
+                        codeResult.Add($"var entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(semiglobal);");
+                        break;
                     default:
                         codeResult.Add($"var entities = context.VM.Entities;");
                         break;

--- a/TSOClient/FSO.SimAntics.JIT/Translation/CSharp/Primitives/CSSetToNextPrimitive.cs
+++ b/TSOClient/FSO.SimAntics.JIT/Translation/CSharp/Primitives/CSSetToNextPrimitive.cs
@@ -96,9 +96,13 @@ namespace FSO.SimAntics.JIT.Translation.CSharp.Primitives
                         csClass.UseParams = true;
                         codeResult.Add($"var entities = context.VM.Context.ObjectQueries.GetObjectsByCategory(args[0]);");
                         break;
-                    case VMSetToNextSearchType.ObjectOfSemiGlobal:
+                    case VMSetToNextSearchType.FSOObjectOfSemiGlobal:
                         codeResult.Add($"var semiglobal = FSO.Content.Content.Get().WorldObjects.Get(operand.GUID).Resource.SemiGlobal;");
-                        codeResult.Add($"var entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(semiglobal);");
+                        codeResult.Add($"if(sg != null) {{ ");
+                        codeResult.Add($"string sg_name = sg.Iff.Filename;");
+                        codeResult.Add($"if(obj.SemiGlobal.Iff.Filename != null) entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(sg_name);");
+                        codeResult.Add($"else entities = null; }}");
+                        codeResult.Add($"else entities = null;");
                         break;
                     default:
                         codeResult.Add($"var entities = context.VM.Entities;");

--- a/TSOClient/FSO.SimAntics.JIT/Translation/CSharp/Primitives/CSSetToNextPrimitive.cs
+++ b/TSOClient/FSO.SimAntics.JIT/Translation/CSharp/Primitives/CSSetToNextPrimitive.cs
@@ -98,9 +98,9 @@ namespace FSO.SimAntics.JIT.Translation.CSharp.Primitives
                         break;
                     case VMSetToNextSearchType.FSOObjectOfSemiGlobal:
                         codeResult.Add($"var semiglobal = FSO.Content.Content.Get().WorldObjects.Get(operand.GUID).Resource.SemiGlobal;");
-                        codeResult.Add($"if(sg != null) {{ ");
+                        codeResult.Add($"if (sg != null) {{ ");
                         codeResult.Add($"string sg_name = sg.Iff.Filename;");
-                        codeResult.Add($"if(obj.SemiGlobal.Iff.Filename != null) entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(sg_name);");
+                        codeResult.Add($"if (obj.SemiGlobal.Iff.Filename != null) entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(sg_name);");
                         codeResult.Add($"else entities = null; }}");
                         codeResult.Add($"else entities = null;");
                         break;

--- a/TSOClient/tso.simantics/Model/VMObjectQueries.cs
+++ b/TSOClient/tso.simantics/Model/VMObjectQueries.cs
@@ -149,7 +149,7 @@ namespace FSO.SimAntics.Model
         public void RegisterSemiGlobal(VMEntity obj, string semiGlobal)
         {
             List<VMEntity> tile = null;
-            if(semiGlobal != null)
+            if (semiGlobal != null)
             {
                 ObjectsBySemiGlobal.TryGetValue(semiGlobal.ToLowerInvariant(), out tile);
                 if (tile == null)
@@ -187,9 +187,9 @@ namespace FSO.SimAntics.Model
             }
             VM.AddToObjList(list, obj);
             RegisterCategory(obj, obj.GetValue(VMStackObjectVariable.Category));
-            if(obj.SemiGlobal != null)
+            if (obj.SemiGlobal != null)
             {
-                if(obj.SemiGlobal.Iff.Filename != null)   //sanity check
+                if (obj.SemiGlobal.Iff.Filename != null) //sanity check
                 {
                     RegisterSemiGlobal(obj, obj.SemiGlobal.Iff.Filename);
                 }
@@ -221,7 +221,7 @@ namespace FSO.SimAntics.Model
             RemoveCategory(obj, obj.GetValue(VMStackObjectVariable.Category));
             if (obj.SemiGlobal != null)
             {
-                if (obj.SemiGlobal.Iff.Filename != null)    //sanity check
+                if (obj.SemiGlobal.Iff.Filename != null) //sanity check
                 {
                     RemoveSemiGlobal(obj, obj.SemiGlobal.Iff.Filename.ToLowerInvariant());
                 }

--- a/TSOClient/tso.simantics/Model/VMObjectQueries.cs
+++ b/TSOClient/tso.simantics/Model/VMObjectQueries.cs
@@ -151,11 +151,11 @@ namespace FSO.SimAntics.Model
             List<VMEntity> tile = null;
             if(semiGlobal != null)
             {
-                ObjectsBySemiGlobal.TryGetValue(semiGlobal, out tile);
+                ObjectsBySemiGlobal.TryGetValue(semiGlobal.ToLowerInvariant(), out tile);
                 if (tile == null)
                 {
                     tile = new List<VMEntity>();
-                    ObjectsBySemiGlobal.Add(semiGlobal, tile);
+                    ObjectsBySemiGlobal.Add(semiGlobal.ToLowerInvariant(), tile);
                 }
                 //debug check: use if things are going weird
                 //if (!tile.Contains(obj))
@@ -223,7 +223,7 @@ namespace FSO.SimAntics.Model
             {
                 if (obj.SemiGlobal.Iff.Filename != null)    //sanity check
                 {
-                    RemoveSemiGlobal(obj, obj.SemiGlobal.Iff.Filename);
+                    RemoveSemiGlobal(obj, obj.SemiGlobal.Iff.Filename.ToLowerInvariant());
                 }
             }
             
@@ -273,7 +273,7 @@ namespace FSO.SimAntics.Model
         public List<VMEntity> GetObjectsBySemiGlobal(string semiGlobal)
         {
             List<VMEntity> tile = null;
-            ObjectsBySemiGlobal.TryGetValue(semiGlobal, out tile);
+            ObjectsBySemiGlobal.TryGetValue(semiGlobal.ToLowerInvariant(), out tile);
             return tile;
         }
     }

--- a/TSOClient/tso.simantics/Model/VMObjectQueries.cs
+++ b/TSOClient/tso.simantics/Model/VMObjectQueries.cs
@@ -16,7 +16,7 @@ namespace FSO.SimAntics.Model
 
         private Dictionary<uint, List<VMEntity>> ObjectsByGUID = new Dictionary<uint, List<VMEntity>>();
         private Dictionary<short, List<VMEntity>> ObjectsByCategory = new Dictionary<short, List<VMEntity>>();
-        private Dictionary<GameGlobalResource, List<VMEntity>> ObjectsBySemiGlobal = new Dictionary<GameGlobalResource, List<VMEntity>>();
+        private Dictionary<string, List<VMEntity>> ObjectsBySemiGlobal = new Dictionary<string, List<VMEntity>>();
         public List<VMEntity> Avatars = new List<VMEntity>();
         public Dictionary<uint, VMAvatar> AvatarsByPersist = new Dictionary<uint, VMAvatar>();
         public Dictionary<uint, VMMultitileGroup> MultitileByPersist = new Dictionary<uint, VMMultitileGroup>();
@@ -146,7 +146,7 @@ namespace FSO.SimAntics.Model
             if (tile.Count == 0) ObjectsByCategory.Remove(category);
         }
 
-        public void RegisterSemiGlobal(VMEntity obj, GameGlobalResource semiGlobal)
+        public void RegisterSemiGlobal(VMEntity obj, string semiGlobal)
         {
             List<VMEntity> tile = null;
             if(semiGlobal != null)
@@ -163,7 +163,7 @@ namespace FSO.SimAntics.Model
             }
         }
 
-        public void RemoveSemiGlobal(VMEntity obj, GameGlobalResource semiGlobal)
+        public void RemoveSemiGlobal(VMEntity obj, string semiGlobal)
         {
             List<VMEntity> tile = null;
             if (semiGlobal != null)
@@ -187,7 +187,14 @@ namespace FSO.SimAntics.Model
             }
             VM.AddToObjList(list, obj);
             RegisterCategory(obj, obj.GetValue(VMStackObjectVariable.Category));
-            RegisterSemiGlobal(obj, obj.SemiGlobal);
+            if(obj.SemiGlobal != null)
+            {
+                if(obj.SemiGlobal.Iff.Filename != null)   //sanity check
+                {
+                    RegisterSemiGlobal(obj, obj.SemiGlobal.Iff.Filename);
+                }
+            }
+            
 
             if (obj is VMAvatar)
             {
@@ -212,7 +219,14 @@ namespace FSO.SimAntics.Model
                 if (list.Count == 0) ObjectsByGUID.Remove(guid);
             }
             RemoveCategory(obj, obj.GetValue(VMStackObjectVariable.Category));
-            RemoveSemiGlobal(obj, obj.SemiGlobal);
+            if (obj.SemiGlobal != null)
+            {
+                if (obj.SemiGlobal.Iff.Filename != null)    //sanity check
+                {
+                    RemoveSemiGlobal(obj, obj.SemiGlobal.Iff.Filename);
+                }
+            }
+            
 
             if (obj is VMAvatar)
             {
@@ -256,7 +270,7 @@ namespace FSO.SimAntics.Model
             return tile;
         }
 
-        public List<VMEntity> GetObjectsBySemiGlobal(GameGlobalResource semiGlobal)
+        public List<VMEntity> GetObjectsBySemiGlobal(string semiGlobal)
         {
             List<VMEntity> tile = null;
             ObjectsBySemiGlobal.TryGetValue(semiGlobal, out tile);

--- a/TSOClient/tso.simantics/Primitives/VMSetToNext.cs
+++ b/TSOClient/tso.simantics/Primitives/VMSetToNext.cs
@@ -94,7 +94,18 @@ namespace FSO.SimAntics.Primitives
                         entities = context.VM.Context.ObjectQueries.GetObjectsByCategory(context.Args[0]); break;
                     case VMSetToNextSearchType.ObjectOfSemiGlobal:
                         var sg = FSO.Content.Content.Get().WorldObjects.Get(operand.GUID).Resource.SemiGlobal;
-                        entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(sg); break;
+
+                        if (sg != null)
+                        {
+                            string sg_name = sg.Iff.Filename;
+                            if (sg_name != null)
+                            {
+                                entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(sg_name);
+                            }
+                            else entities = null;
+                        }
+                        else entities = null;
+                        break;
                     default:
                         break;
                 }

--- a/TSOClient/tso.simantics/Primitives/VMSetToNext.cs
+++ b/TSOClient/tso.simantics/Primitives/VMSetToNext.cs
@@ -100,7 +100,7 @@ namespace FSO.SimAntics.Primitives
                             string sg_name = sg.Iff.Filename;   //retrieve semiglobal's iff filename
                             if (sg_name != null) //sanity check
                             {
-                                entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(sg_name);
+                                entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(sg_name.ToLowerInvariant());
                             }
                             else entities = null;
                         }

--- a/TSOClient/tso.simantics/Primitives/VMSetToNext.cs
+++ b/TSOClient/tso.simantics/Primitives/VMSetToNext.cs
@@ -92,13 +92,13 @@ namespace FSO.SimAntics.Primitives
                         entities = context.VM.Context.ObjectQueries.GetObjectsByGUID(operand.GUID); break;
                     case VMSetToNextSearchType.ObjectWithCategoryEqualToSP0:
                         entities = context.VM.Context.ObjectQueries.GetObjectsByCategory(context.Args[0]); break;
-                    case VMSetToNextSearchType.ObjectOfSemiGlobal:
+                    case VMSetToNextSearchType.FSOObjectOfSemiGlobal:
                         var sg = FSO.Content.Content.Get().WorldObjects.Get(operand.GUID).Resource.SemiGlobal;
 
                         if (sg != null)
                         {
-                            string sg_name = sg.Iff.Filename;
-                            if (sg_name != null)
+                            string sg_name = sg.Iff.Filename;   //retrieve semiglobal's iff filename
+                            if (sg_name != null) //sanity check
                             {
                                 entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(sg_name);
                             }
@@ -293,7 +293,7 @@ namespace FSO.SimAntics.Primitives
         #endregion
     }
 
-
+    //Max value is 127
     public enum VMSetToNextSearchType
     {
         Object = 0,
@@ -309,6 +309,8 @@ namespace FSO.SimAntics.Primitives
         Career = 10,
         ClosestHouse = 11,
         FamilyMember = 12, //TS1.5 or higher
-        ObjectOfSemiGlobal = 13,
+
+        //FSO
+        FSOObjectOfSemiGlobal = 100,
     }
 }

--- a/TSOClient/tso.simantics/Primitives/VMSetToNext.cs
+++ b/TSOClient/tso.simantics/Primitives/VMSetToNext.cs
@@ -97,7 +97,7 @@ namespace FSO.SimAntics.Primitives
 
                         if (sg != null)
                         {
-                            string sg_name = sg.Iff.Filename;   //retrieve semiglobal's iff filename
+                            string sg_name = sg.Iff.Filename; //retrieve semiglobal's iff filename
                             if (sg_name != null) //sanity check
                             {
                                 entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(sg_name.ToLowerInvariant());

--- a/TSOClient/tso.simantics/Primitives/VMSetToNext.cs
+++ b/TSOClient/tso.simantics/Primitives/VMSetToNext.cs
@@ -92,6 +92,9 @@ namespace FSO.SimAntics.Primitives
                         entities = context.VM.Context.ObjectQueries.GetObjectsByGUID(operand.GUID); break;
                     case VMSetToNextSearchType.ObjectWithCategoryEqualToSP0:
                         entities = context.VM.Context.ObjectQueries.GetObjectsByCategory(context.Args[0]); break;
+                    case VMSetToNextSearchType.ObjectOfSemiGlobal:
+                        var sg = FSO.Content.Content.Get().WorldObjects.Get(operand.GUID).Resource.SemiGlobal;
+                        entities = context.VM.Context.ObjectQueries.GetObjectsBySemiGlobal(sg); break;
                     default:
                         break;
                 }
@@ -295,5 +298,6 @@ namespace FSO.SimAntics.Primitives
         Career = 10,
         ClosestHouse = 11,
         FamilyMember = 12, //TS1.5 or higher
+        ObjectOfSemiGlobal = 13,
     }
 }


### PR DESCRIPTION
The primitive Set To Next allows for a new operator called "object with same semiglobal as", which iterates through any object whose semiglobal is shared with the object type that has been chosen.