### PR TITLE
Handle DirectoryNotFoundException if the SplashScreens directory does not exist

### DIFF
--- a/TSOClient/tso.client/UI/Panels/UISetupBackground.cs
+++ b/TSOClient/tso.client/UI/Panels/UISetupBackground.cs
@@ -58,7 +58,11 @@ namespace FSO.Client.UI.Panels
             {
                 // Just attempt to load the regular setup.png.
             }
-            
+            catch (DirectoryNotFoundException)
+            {
+                // Just attempt to load the regular setup.png.
+            }
+
             if (splashes != null && splashes.Length > 0)
             {
                 Random rng = new Random();


### PR DESCRIPTION
I recently started working with the repo and saw that this throws an Exception on a clean repo install, apparently this folder is optional but its DirectoryException is not handled.