### PR TITLE
QoL- Adds a sound when timeout dialog renders

### DIFF
--- a/TSOClient/tso.client/UI/Panels/UISetupBackground.cs
+++ b/TSOClient/tso.client/UI/Panels/UISetupBackground.cs
@@ -35,6 +35,9 @@ namespace FSO.Client.UI.Panels
 
             try
             {
+                if (!Directory.Exists("Content/SplashScreens"))
+                    throw new FileNotFoundException();
+
                 splashes = File.ReadAllLines("Content/SplashScreens/list.txt");
 
                 // Validate that the listed splash screens exist.

--- a/TSOClient/tso.client/UI/Screens/CoreGameScreen.cs
+++ b/TSOClient/tso.client/UI/Screens/CoreGameScreen.cs
@@ -746,6 +746,7 @@ namespace FSO.Client.UI.Screens
                     UIScreen.GlobalShowDialog(dialog, true);
                     var rnd = new Random();
                     dialog.Position = new Vector2(rnd.Next(Math.Max(0, ScreenWidth - 380)), rnd.Next(Math.Max(0, ScreenHeight - 180)));
+                    HITVM.Get().PlaySoundEvent(UISounds.CallQueueFull);
                     break;
             }
         }


### PR DESCRIPTION
Just a quick quality of life change to help people who don't actively watch the screen. They can hear the same alert as if they received an interaction request from another player.

Since this is my first merge request, you can find me in discord Bolune#7147 if you need to DM me. 

Note: I know little about all the possible sounds for the game so I just took what made sense. If another sound alert makes sense, feel free to let me know.

### What was changed?

- Fix a crash when splash folder does not exist by checking for directory and treating it like a missing file
- Plays a sound when the timeout dialog shows up (the same sound for receiving interactions from other players)

### How to test?

1. Load game without "SplashScreens" folder.
2. Wait for timeout dialog to show up or send a request from the server.
