### PR TITLE
#83 - adds shift+end and shift+home functionality

### DIFF
--- a/TSOClient/tso.common/Rendering/Framework/IO/InputManager.cs
+++ b/TSOClient/tso.common/Rendering/Framework/IO/InputManager.cs
@@ -271,12 +271,23 @@ namespace FSO.Common.Rendering.Framework.IO
                                     didChange = true;
                                 }
                                 break;
-                            }
-                        } else {
-                            result.UnhandledKeys.Add(key);
-                            processChar = true;
                         }
+                    } 
+                    else if (key == Keys.Home)
+                    {
+                        cursorIndex = 0;
+                        result.SelectionChanged = true;
                     }
+                    else if (key == Keys.End)
+                    {
+                        cursorIndex = m_SBuilder.Length;
+                        result.SelectionChanged = true;
+                    }
+                    else {
+                        result.UnhandledKeys.Add(key);
+                        processChar = true;
+                    }
+                }
 
                 if (processChar)
                 {

--- a/TSOClient/tso.common/Rendering/Framework/IO/InputManager.cs
+++ b/TSOClient/tso.common/Rendering/Framework/IO/InputManager.cs
@@ -198,6 +198,20 @@ namespace FSO.Common.Rendering.Framework.IO
                     {
                         result.TabPressed = true;
                     }
+                    else if (result.ShiftDown)
+                    {
+                        switch (key)
+                        {
+                            case Keys.Home:
+                                cursorEndIndex = 0;
+                                result.SelectionChanged = true;
+                                break;
+                            case Keys.End:
+                                cursorEndIndex = m_SBuilder.Length;
+                                result.SelectionChanged = true;
+                                break;
+                        }
+                    }
                     else if (result.CtrlDown)
                     {
                         switch (key)

--- a/TSOClient/tso.common/Rendering/Framework/IO/InputManager.cs
+++ b/TSOClient/tso.common/Rendering/Framework/IO/InputManager.cs
@@ -283,7 +283,8 @@ namespace FSO.Common.Rendering.Framework.IO
                         cursorIndex = m_SBuilder.Length;
                         result.SelectionChanged = true;
                     }
-                    else {
+                    else 
+                    {
                         result.UnhandledKeys.Add(key);
                         processChar = true;
                     }


### PR DESCRIPTION
### What was changed?

- Adds the shift+end and shift+home functionality to the InputManager code
- Adds the end and home functionality to bring cursor to beginning or end
- Removed extra tabs from the ending portion of the long if-else statement to make it match up

### How to test?

- Type something in a text box and move the cursor to the center
- Hit Shift+End to select everything from cursor to the end
- Hit Shift+Home to select everything from start to cursor
- Use End to move cursor to end
- Use Home to move cursor to beginning