### PR TITLE
Possible? Fix for when you click into the Window without focus and it doesn't properly select UIElements

### DIFF
--- a/TSOClient/tso.common/Rendering/Framework/GameScreen.cs
+++ b/TSOClient/tso.common/Rendering/Framework/GameScreen.cs
@@ -108,16 +108,8 @@ namespace FSO.Common.Rendering.Framework
             else
             {
                 //single mouse state
-                if (hasFocus)
-                {
-                    State.MouseState = Mouse.GetState();
-                    State.KeyboardState = Keyboard.GetState();
-                }
-                else
-                {
-                    State.MouseState = new MouseState();
-                    State.KeyboardState = new KeyboardState();
-                }
+                State.KeyboardState = hasFocus ? Keyboard.GetState() : new KeyboardState();
+                State.MouseState = Mouse.GetState(); 
 
                 if (State.KeyboardState.IsKeyDown(Keys.LeftAlt) && State.MouseState.LeftButton == ButtonState.Pressed)
                 {

--- a/TSOClient/tso.common/Rendering/Framework/Model/UpdateState.cs
+++ b/TSOClient/tso.common/Rendering/Framework/Model/UpdateState.cs
@@ -76,7 +76,7 @@ namespace FSO.Common.Rendering.Framework.Model
         {
             get
             {
-                return WindowFocused && MouseOverWindow;
+                return MouseOverWindow;
             }
         }
 


### PR DESCRIPTION
What is happening is that when the game is not focused and you go to click on a UIElement, the game gets focused and doesn't trigger the UIElement click properly. Rather it passes the click down to the lot/terrain world instead. 

You can see this happen when you try to click into the chat window. 

Note: I am not 100% sure what this change can also affect. I have not seen any negative affects on the Windows FreeSO of things. So don't take this merge without proper review.

### What changed?

- Allow mouse events to be handled when window is not focused.

### How to test?
- Launch game & click on a UIElement without having Window Focus
- It should properly click and trigger hover over tooltips instead of being treated like a lot click