### PR TITLE
fix: pie menu no longer glitches for 1 frame.

### DIFF
--- a/TSOClient/tso.client/UI/Panels/UIPieMenu.cs
+++ b/TSOClient/tso.client/UI/Panels/UIPieMenu.cs
@@ -77,7 +77,8 @@ namespace FSO.Client.UI.Panels
 
             lerpSpeed = 0.125f * (60.0f / FSOEnvironment.RefreshRate);
             m_Bg = new UIImage(TextureGenerator.GetPieBG(GameFacade.GraphicsDevice));
-            m_Bg.SetSize(0, 0); //is scaled up later
+            m_Bg.SetSize(2, 2); //is scaled up later
+            m_Bg.Position = new Vector2(-1, -1);
             this.AddAt(0, m_Bg);
 
             m_PieTree = new UIPieMenuItem()


### PR DESCRIPTION
Pie menu no longer displays 1 frame of the background at full size before resizing. The Image component considers Width/Height==0 to mean don't scale the image at all (has no way to represent unset/null). Instead of changing the image component and risking breaking other usages this just starts the background at 2x2.