### PR TITLE
[VM] 3D audio panning

### DIFF
--- a/TSOClient/tso.client/Rendering/City/CityGeometry.cs
+++ b/TSOClient/tso.client/Rendering/City/CityGeometry.cs
@@ -468,11 +468,14 @@ namespace FSO.Client.Rendering.City
 
             RoadIndices?.Dispose();
             RoadVertices?.Dispose();
-            RoadIndices = new IndexBuffer(gd, IndexElementSize.ThirtyTwoBits, roadIndices.Count, BufferUsage.None);
-            RoadIndices.SetData(roadIndices.ToArray());
-            RoadVertices = new VertexBuffer(gd, typeof(TLayerVertex), roadVertices.Count, BufferUsage.None);
-            RoadVertices.SetData(roadVertices.ToArray());
-            RoadPrims = roadIndices.Count / 3;
+            if (roadVertices.Count > 0)
+            {
+                RoadIndices = new IndexBuffer(gd, IndexElementSize.ThirtyTwoBits, roadIndices.Count, BufferUsage.None);
+                RoadIndices.SetData(roadIndices.ToArray());
+                RoadVertices = new VertexBuffer(gd, typeof(TLayerVertex), roadVertices.Count, BufferUsage.None);
+                RoadVertices.SetData(roadVertices.ToArray());
+                RoadPrims = roadIndices.Count / 3;
+            }
         }
 
         private int O(int x, int y, int minx, int maxx)

--- a/TSOClient/tso.simantics/Entities/VMAvatar.cs
+++ b/TSOClient/tso.simantics/Entities/VMAvatar.cs
@@ -490,6 +490,7 @@ namespace FSO.SimAntics
                         Zoom = true,
                     };
                     owner.SoundThreads.Add(entry);
+                    owner.Thread.Context.VM.SoundEntities.Add(this);
                     owner.TickSounds();
                 }
             }

--- a/TSOClient/tso.simantics/Entities/VMEntity.cs
+++ b/TSOClient/tso.simantics/Entities/VMEntity.cs
@@ -369,7 +369,6 @@ namespace FSO.SimAntics
                     float pan = (SoundThreads[i].Pan) ? Math.Max(-1.0f, Math.Min(1.0f, scrPos.X / worldSpace.WorldPxWidth)) : 0;
                     pan = pan * pan * ((pan > 0)?1:-1);
 
-
                     float volume = 1f;
                     
                     var rcs = worldState.Cameras.ActiveCamera as CameraController3D;
@@ -382,6 +381,29 @@ namespace FSO.SimAntics
                         volume = 1.5f - delta.Length() / 40f;
                         volume *= (10 / ((rcs.Zoom3D * rcs.Zoom3D) + 10));
                         volume *= worldState.PreciseZoom;
+
+                        //Calculate 3D sound
+                        if (SoundThreads[i].Pan)
+                        {
+                            //Calculate camera vectors and heading relative to sound source
+                            var sourcePos = new Vector3(vp.X, vp.Z, vp.Y);
+
+                            var lookAt = rcs.Camera.Target - rcs.Camera.Position;
+                            lookAt.Normalize();
+
+                            var lookUp = Vector3.Up;
+
+                            var lookSide = Vector3.Cross(lookAt, lookUp);
+                            lookSide.Normalize();
+
+                            var heading = sourcePos - rcs.Camera.Position;
+                            heading.Normalize();
+
+                            pan = Vector3.Dot(lookSide, heading);
+
+                            //Tweak exponent so that sounds don't go off one ear too soon
+                            pan = (float)Math.Pow(Math.Abs(pan), 2.25f) * Math.Sign(pan);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Adds specific code for panning entity sounds while in 3D mode, as previously the 2D code was used causing it to jump around and be inaccurate.
Avatars are also now added to the VM sound entities when they play a sound from an event, so that it pans around as you move the camera rather than staying in place.