### PR TITLE
Volcanic - Fixes and QoL changes.

### DIFF
--- a/TSOClient/FSO.IDE/EditorComponent/Commands/SetFirstCommand.cs
+++ b/TSOClient/FSO.IDE/EditorComponent/Commands/SetFirstCommand.cs
@@ -46,11 +46,19 @@ namespace FSO.IDE.EditorComponent.Commands
             }
             else
             {
+                var old0View = editor.BHAVView.Primitives.First(prim => prim.InstPtr == 0);
+                var new0View = editor.BHAVView.Primitives.First(prim => prim.InstPtr == OldPtr);
+                var old0Box = old0View.TreeBox;
+                var new0Box = new0View.TreeBox;
+
+                old0View.TreeBox = new0Box;
+                new0View.TreeBox = old0Box;
+                old0View.CopyPosToTree();
+                new0View.CopyPosToTree();
+
                 bhav.Instructions[0] = Primitive.Instruction;
                 bhav.Instructions[OldPtr] = Old0.Instruction;
-                // TODO
-                //Primitive.InstPtr = 0;
-                //Old0.InstPtr = OldPtr;
+
                 foreach (var prim in FromTrue) prim.Instruction.TruePointer = 0;
                 foreach (var prim in FromFalse) prim.Instruction.FalsePointer = 0;
                 foreach (var prim in FromTrue0) prim.Instruction.TruePointer = OldPtr;
@@ -68,11 +76,19 @@ namespace FSO.IDE.EditorComponent.Commands
             }
             else
             {
+                var old0View = editor.BHAVView.Primitives.First(prim => prim.InstPtr == 0);
+                var new0View = editor.BHAVView.Primitives.First(prim => prim.InstPtr == OldPtr);
+                var old0Box = old0View.TreeBox;
+                var new0Box = new0View.TreeBox;
+
+                old0View.TreeBox = new0Box;
+                new0View.TreeBox = old0Box;
+                old0View.CopyPosToTree();
+                new0View.CopyPosToTree();
+
                 bhav.Instructions[0] = Old0.Instruction;
                 bhav.Instructions[OldPtr] = Primitive.Instruction;
-                // TODO
-                //Primitive.InstPtr = OldPtr;
-                //Old0.InstPtr = 0;
+
                 foreach (var prim in FromTrue) prim.Instruction.TruePointer = OldPtr;
                 foreach (var prim in FromFalse) prim.Instruction.FalsePointer = OldPtr;
                 foreach (var prim in FromTrue0) prim.Instruction.TruePointer = 0;

--- a/TSOClient/FSO.IDE/EditorComponent/EditorScope.cs
+++ b/TSOClient/FSO.IDE/EditorComponent/EditorScope.cs
@@ -261,10 +261,10 @@ namespace FSO.IDE.EditorComponent
             {
                 case 0: //local
                     bcon = Object.Resource.Get<BCON>((ushort)(tableID + 4096));
-                    if (bcon != null) return (short)bcon.Constants[keyID];
+                    if (bcon != null && keyID < bcon.Constants.Length) return (short)bcon.Constants[keyID];
 
                     tuning = Object.Resource.Get<OTFTable>((ushort)(tableID + 4096));
-                    if (tuning != null) return (short?)tuning.GetKey(keyID)?.Value ?? (short)0;
+                    if (tuning != null) return (short)(tuning.GetKey(keyID)?.Value ?? 0);
                     break;
                 case 1: //semi globals
                     ushort testTab = (ushort)(tableID + 8192);
@@ -272,7 +272,7 @@ namespace FSO.IDE.EditorComponent
                     if (bcon != null && keyID < bcon.Constants.Length) return (short)bcon.Constants[keyID];
 
                     tuning = Object.Resource.Get<OTFTable>(testTab);
-                    if (tuning != null) return (short)tuning.GetKey(keyID).Value;
+                    if (tuning != null) return (short)(tuning.GetKey(keyID)?.Value ?? 0);
 
                     if (SemiGlobal != null)
                     {
@@ -280,7 +280,7 @@ namespace FSO.IDE.EditorComponent
                         if (bcon != null && keyID < bcon.Constants.Length) return (short)bcon.Constants[keyID];
 
                         tuning = SemiGlobal.Get<OTFTable>(testTab);
-                        if (tuning != null) return (short)tuning.GetKey(keyID).Value;
+                        if (tuning != null) return (short)(tuning.GetKey(keyID)?.Value ?? 0);
                     }
                     break;
                 case 2: //global
@@ -309,12 +309,19 @@ namespace FSO.IDE.EditorComponent
             /** This could be in a BCON or an OTF **/
             BCON bcon;
             OTFTable tuning;
+            TRCN labels;
+
             switch (mode)
             {
                 case 0:
                     bcon = Object.Resource.Get<BCON>((ushort)(tableID + 4096));
+                    labels = Object.Resource.Get<TRCN>((ushort)(tableID + 4096));
                     if (bcon != null)
                     {
+                        if (labels != null && keyID < labels.Entries.Length)
+                        {
+                            return labels.Entries[keyID].Label + " #" + keyID;
+                        }
                         return bcon.ChunkLabel + " #" + keyID;
                     }
 
@@ -327,8 +334,13 @@ namespace FSO.IDE.EditorComponent
                 case 1:
                     if (SemiGlobal == null) break;
                     bcon = SemiGlobal.Get<BCON>((ushort)(tableID + 8192));
+                    labels = Object.Resource.Get<TRCN>((ushort)(tableID + 8192));
                     if (bcon != null)
                     {
+                        if (labels != null && keyID < labels.Entries.Length)
+                        {
+                            return labels.Entries[keyID].Label + " #" + keyID;
+                        }
                         return bcon.ChunkLabel + " #" + keyID;
                     }
 
@@ -340,8 +352,13 @@ namespace FSO.IDE.EditorComponent
                     break;
                 case 2:
                     bcon = Globals.Resource.Get<BCON>((ushort)(tableID + 256));
+                    labels = Object.Resource.Get<TRCN>((ushort)(tableID + 256));
                     if (bcon != null)
                     {
+                        if (labels != null && keyID < labels.Entries.Length)
+                        {
+                            return labels.Entries[keyID].Label + " #" + keyID;
+                        }
                         return bcon.ChunkLabel + " #" + keyID;
                     }
 

--- a/TSOClient/FSO.IDE/EditorComponent/VarSoundSelect.cs
+++ b/TSOClient/FSO.IDE/EditorComponent/VarSoundSelect.cs
@@ -126,7 +126,7 @@ namespace FSO.IDE.EditorComponent
                     }
                 }
                 fwav.ChunkID = resultID;
-                fwav.ChunkLabel = "";
+                fwav.ChunkLabel = name;
 
                 SourceIff.AddChunk(fwav);
                 fwav.AddedByPatch = true;

--- a/TSOClient/FSO.IDE/EditorComponent/VarSoundSelect.cs
+++ b/TSOClient/FSO.IDE/EditorComponent/VarSoundSelect.cs
@@ -112,6 +112,7 @@ namespace FSO.IDE.EditorComponent
             fwav.Name = name;
             fwav.ChunkParent = SourceIff;
             fwav.ChunkProcessed = true;
+            fwav.ChunkType = "FWAV";
 
             Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
             {

--- a/TSOClient/FSO.IDE/EntityInspector.Designer.cs
+++ b/TSOClient/FSO.IDE/EntityInspector.Designer.cs
@@ -37,6 +37,7 @@
             this.RefreshButton = new System.Windows.Forms.Button();
             this.TracerButton = new System.Windows.Forms.Button();
             this.DeleteButton = new System.Windows.Forms.Button();
+            this.OpenResource = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // EntityView
@@ -53,7 +54,6 @@
             this.EntityView.FullRowSelect = true;
             this.EntityView.HideSelection = false;
             this.EntityView.Location = new System.Drawing.Point(3, 3);
-            this.EntityView.MultiSelect = false;
             this.EntityView.Name = "EntityView";
             this.EntityView.Size = new System.Drawing.Size(615, 452);
             this.EntityView.TabIndex = 0;
@@ -109,7 +109,7 @@
             // DeleteButton
             // 
             this.DeleteButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.DeleteButton.Location = new System.Drawing.Point(624, 403);
+            this.DeleteButton.Location = new System.Drawing.Point(624, 374);
             this.DeleteButton.Name = "DeleteButton";
             this.DeleteButton.Size = new System.Drawing.Size(103, 23);
             this.DeleteButton.TabIndex = 3;
@@ -117,10 +117,22 @@
             this.DeleteButton.UseVisualStyleBackColor = true;
             this.DeleteButton.Click += new System.EventHandler(this.DeleteButton_Click);
             // 
+            // OpenResource
+            // 
+            this.OpenResource.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.OpenResource.Location = new System.Drawing.Point(624, 403);
+            this.OpenResource.Name = "OpenResource";
+            this.OpenResource.Size = new System.Drawing.Size(103, 23);
+            this.OpenResource.TabIndex = 4;
+            this.OpenResource.Text = "Open Resource";
+            this.OpenResource.UseVisualStyleBackColor = true;
+            this.OpenResource.Click += new System.EventHandler(this.OpenResource_Click);
+            // 
             // EntityInspector
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.OpenResource);
             this.Controls.Add(this.DeleteButton);
             this.Controls.Add(this.TracerButton);
             this.Controls.Add(this.RefreshButton);
@@ -142,5 +154,6 @@
         private System.Windows.Forms.Button RefreshButton;
         private System.Windows.Forms.Button TracerButton;
         private System.Windows.Forms.Button DeleteButton;
+        private System.Windows.Forms.Button OpenResource;
     }
 }

--- a/TSOClient/FSO.IDE/EntityInspector.cs
+++ b/TSOClient/FSO.IDE/EntityInspector.cs
@@ -97,16 +97,16 @@ namespace FSO.IDE
         private void DeleteButton_Click(object sender, EventArgs e)
         {
             if (EntityView.SelectedIndices == null || EntityView.SelectedIndices.Count == 0) return;
-            for(var i=0;i<EntityView.SelectedItems.Count;i++)
+            foreach (ListViewItem item in EntityView.SelectedItems)
             {
                 // Send a delete command in addition to deleting the object locally to allow deletion by admin clients.
                 HookedVM.SendCommand(new VMNetDeleteObjectCmd()
                 {
-                    ObjectID = ItemToEnt[EntityView.SelectedItems[i]].ID,
+                    ObjectID = ItemToEnt[item].ID,
                     CleanupAll = true
                 });
-                var item = ItemToEnt[EntityView.SelectedItems[i]];
-                Content.Content.Get().Changes.Invoke((Action<bool, VMContext>)item.Entity.Delete, true, item.Entity.Thread.Context);
+                var ent = ItemToEnt[item];
+                Content.Content.Get().Changes.Invoke((Action<bool, VMContext>)ent.Entity.Delete, true, ent.Entity.Thread.Context);
             }
             RefreshView();
         }
@@ -114,9 +114,9 @@ namespace FSO.IDE
         private void OpenResource_Click(object sender, EventArgs e)
         {
             if (EntityView.SelectedIndices == null || EntityView.SelectedIndices.Count == 0) return;
-            for (var i = 0; i < EntityView.SelectedItems.Count; i++)
+            foreach (ListViewItem item in EntityView.SelectedItems)
             {
-                MainWindow.Instance.IffManager.OpenResourceWindow(ItemToEnt[EntityView.SelectedItems[i]].Entity.Object);
+                MainWindow.Instance.IffManager.OpenResourceWindow(ItemToEnt[item].Entity.Object);
             }
         }
     }

--- a/TSOClient/FSO.IDE/EntityInspector.cs
+++ b/TSOClient/FSO.IDE/EntityInspector.cs
@@ -11,6 +11,7 @@ using FSO.SimAntics;
 using FSO.Common.Utils;
 using System.Threading;
 using System.Diagnostics;
+using FSO.SimAntics.NetPlay.Model.Commands;
 
 namespace FSO.IDE
 {
@@ -96,9 +97,27 @@ namespace FSO.IDE
         private void DeleteButton_Click(object sender, EventArgs e)
         {
             if (EntityView.SelectedIndices == null || EntityView.SelectedIndices.Count == 0) return;
-            var item = ItemToEnt[EntityView.SelectedItems[0]];
-            Content.Content.Get().Changes.Invoke((Action<bool, VMContext>)item.Entity.Delete, true, item.Entity.Thread.Context);
+            for(var i=0;i<EntityView.SelectedItems.Count;i++)
+            {
+                // Send a delete command in addition to deleting the object locally to allow deletion by admin clients.
+                HookedVM.SendCommand(new VMNetDeleteObjectCmd()
+                {
+                    ObjectID = ItemToEnt[EntityView.SelectedItems[i]].ID,
+                    CleanupAll = true
+                });
+                var item = ItemToEnt[EntityView.SelectedItems[i]];
+                Content.Content.Get().Changes.Invoke((Action<bool, VMContext>)item.Entity.Delete, true, item.Entity.Thread.Context);
+            }
             RefreshView();
+        }
+
+        private void OpenResource_Click(object sender, EventArgs e)
+        {
+            if (EntityView.SelectedIndices == null || EntityView.SelectedIndices.Count == 0) return;
+            for (var i = 0; i < EntityView.SelectedItems.Count; i++)
+            {
+                MainWindow.Instance.IffManager.OpenResourceWindow(ItemToEnt[EntityView.SelectedItems[i]].Entity.Object);
+            }
         }
     }
 

--- a/TSOClient/FSO.IDE/MainWindow.Designer.cs
+++ b/TSOClient/FSO.IDE/MainWindow.Designer.cs
@@ -56,6 +56,7 @@
             this.saveGlobalscsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.avatarToolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openExternalIffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fieldEncodingReverserToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.windowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hideAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -77,10 +78,9 @@
             this.ChangesView = new System.Windows.Forms.TreeView();
             this.BrowserTab = new System.Windows.Forms.TabPage();
             this.NewOBJButton = new System.Windows.Forms.Button();
-            this.Browser = new FSO.IDE.ObjectBrowser();
             this.InspectorTab = new System.Windows.Forms.TabPage();
+            this.Browser = new FSO.IDE.ObjectBrowser();
             this.entityInspector1 = new FSO.IDE.EntityInspector();
-            this.fieldEncodingReverserToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.UtilityTabs.SuspendLayout();
             this.OverviewTab.SuspendLayout();
@@ -208,6 +208,13 @@
             this.openExternalIffToolStripMenuItem.Size = new System.Drawing.Size(199, 22);
             this.openExternalIffToolStripMenuItem.Text = "Open External Iff...";
             this.openExternalIffToolStripMenuItem.Click += new System.EventHandler(this.openExternalIffToolStripMenuItem_Click);
+            // 
+            // fieldEncodingReverserToolStripMenuItem
+            // 
+            this.fieldEncodingReverserToolStripMenuItem.Name = "fieldEncodingReverserToolStripMenuItem";
+            this.fieldEncodingReverserToolStripMenuItem.Size = new System.Drawing.Size(199, 22);
+            this.fieldEncodingReverserToolStripMenuItem.Text = "Field Encoding Reverser";
+            this.fieldEncodingReverserToolStripMenuItem.Click += new System.EventHandler(this.fieldEncodingReverserToolStripMenuItem_Click);
             // 
             // windowToolStripMenuItem
             // 
@@ -455,16 +462,6 @@
             this.NewOBJButton.UseVisualStyleBackColor = true;
             this.NewOBJButton.Click += new System.EventHandler(this.NewOBJButton_Click);
             // 
-            // Browser
-            // 
-            this.Browser.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.Browser.Location = new System.Drawing.Point(3, 3);
-            this.Browser.Name = "Browser";
-            this.Browser.Size = new System.Drawing.Size(724, 452);
-            this.Browser.TabIndex = 0;
-            // 
             // InspectorTab
             // 
             this.InspectorTab.Controls.Add(this.entityInspector1);
@@ -476,6 +473,16 @@
             this.InspectorTab.Text = "VMEntity Inspector";
             this.InspectorTab.UseVisualStyleBackColor = true;
             // 
+            // Browser
+            // 
+            this.Browser.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.Browser.Location = new System.Drawing.Point(3, 3);
+            this.Browser.Name = "Browser";
+            this.Browser.Size = new System.Drawing.Size(724, 452);
+            this.Browser.TabIndex = 0;
+            // 
             // entityInspector1
             // 
             this.entityInspector1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -485,13 +492,6 @@
             this.entityInspector1.Name = "entityInspector1";
             this.entityInspector1.Size = new System.Drawing.Size(724, 452);
             this.entityInspector1.TabIndex = 0;
-            // 
-            // fieldEncodingReverserToolStripMenuItem
-            // 
-            this.fieldEncodingReverserToolStripMenuItem.Name = "fieldEncodingReverserToolStripMenuItem";
-            this.fieldEncodingReverserToolStripMenuItem.Size = new System.Drawing.Size(199, 22);
-            this.fieldEncodingReverserToolStripMenuItem.Text = "Field Encoding Reverser";
-            this.fieldEncodingReverserToolStripMenuItem.Click += new System.EventHandler(this.fieldEncodingReverserToolStripMenuItem_Click);
             // 
             // MainWindow
             // 

--- a/TSOClient/FSO.IDE/ResourceBrowser/IFFResComponent.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/IFFResComponent.cs
@@ -374,6 +374,7 @@ namespace FSO.IDE.ResourceBrowser
                 chunk.ChunkParent.FullRemoveChunk(chunk);
                 Content.Content.Get().Changes.ChunkChanged(chunk);
             }));
+            RefreshResList();
         }
 
         private void CopyRes_Click(object sender, EventArgs e)

--- a/TSOClient/FSO.IDE/ResourceBrowser/IffNameDialog.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/IffNameDialog.cs
@@ -30,16 +30,19 @@ namespace FSO.IDE.ResourceBrowser
             if (chunk is BHAV && chunk.ChunkParent.RuntimeInfo.UseCase == IffUseCase.Object)
                 ChunkIDEntry.Minimum = 4096;
             ChunkIDEntry.Value = Math.Max(ChunkIDEntry.Minimum, Math.Min(ChunkIDEntry.Maximum, chunk.ChunkID));
-            for (var i= ChunkIDEntry.Minimum; i<ChunkIDEntry.Maximum;i++)
+            if (newChunk)
             {
-                MethodInfo method = typeof(IffFile).GetMethod("Get");
-                MethodInfo generic = method.MakeGenericMethod(Chunk.GetType());
-                var iff = Chunk.ChunkParent;
-                var chnk = (IffChunk)generic.Invoke(iff, new object[] { (ushort)i });
-                if (chnk == null)
+                for (var i = ChunkIDEntry.Minimum; i < ChunkIDEntry.Maximum; i++)
                 {
-                    ChunkIDEntry.Value = i;
-                    break;
+                    MethodInfo method = typeof(IffFile).GetMethod("Get");
+                    MethodInfo generic = method.MakeGenericMethod(Chunk.GetType());
+                    var iff = Chunk.ChunkParent;
+                    var chnk = (IffChunk)generic.Invoke(iff, new object[] { (ushort)i });
+                    if (chnk == null)
+                    {
+                        ChunkIDEntry.Value = i;
+                        break;
+                    }
                 }
             }
         }

--- a/TSOClient/FSO.IDE/ResourceBrowser/IffNameDialog.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/IffNameDialog.cs
@@ -29,8 +29,19 @@ namespace FSO.IDE.ResourceBrowser
 
             if (chunk is BHAV && chunk.ChunkParent.RuntimeInfo.UseCase == IffUseCase.Object)
                 ChunkIDEntry.Minimum = 4096;
-
             ChunkIDEntry.Value = Math.Max(ChunkIDEntry.Minimum, Math.Min(ChunkIDEntry.Maximum, chunk.ChunkID));
+            for (var i= ChunkIDEntry.Minimum; i<ChunkIDEntry.Maximum;i++)
+            {
+                MethodInfo method = typeof(IffFile).GetMethod("Get");
+                MethodInfo generic = method.MakeGenericMethod(Chunk.GetType());
+                var iff = Chunk.ChunkParent;
+                var chnk = (IffChunk)generic.Invoke(iff, new object[] { (ushort)i });
+                if (chnk == null)
+                {
+                    ChunkIDEntry.Value = i;
+                    break;
+                }
+            }
         }
 
         private void OKButton_Click(object sender, EventArgs e)

--- a/TSOClient/FSO.IDE/ResourceBrowser/IffNameDialog.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/IffNameDialog.cs
@@ -29,7 +29,7 @@ namespace FSO.IDE.ResourceBrowser
 
             if (chunk is BHAV || chunk is BCON)
             {
-                switch(chunk.ChunkParent.RuntimeInfo.UseCase)
+                switch (chunk.ChunkParent.RuntimeInfo.UseCase)
                 {
                     case IffUseCase.Object:
                         ChunkIDEntry.Minimum = 4096;

--- a/TSOClient/FSO.IDE/ResourceBrowser/IffNameDialog.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/IffNameDialog.cs
@@ -27,8 +27,21 @@ namespace FSO.IDE.ResourceBrowser
             ChunkLabelEntry.Text = chunk.ChunkLabel;
             NewChunk = newChunk;
 
-            if (chunk is BHAV && chunk.ChunkParent.RuntimeInfo.UseCase == IffUseCase.Object)
-                ChunkIDEntry.Minimum = 4096;
+            if (chunk is BHAV || chunk is BCON)
+            {
+                switch(chunk.ChunkParent.RuntimeInfo.UseCase)
+                {
+                    case IffUseCase.Object:
+                        ChunkIDEntry.Minimum = 4096;
+                        break;
+                    case IffUseCase.Global:
+                        if (chunk.ChunkParent.Filename == "global.iff")
+                            ChunkIDEntry.Minimum = 256;
+                        else
+                            ChunkIDEntry.Minimum = 8192;
+                        break;
+                }
+            }
             ChunkIDEntry.Value = Math.Max(ChunkIDEntry.Minimum, Math.Min(ChunkIDEntry.Maximum, chunk.ChunkID));
             if (newChunk)
             {

--- a/TSOClient/FSO.IDE/ResourceBrowser/OBJDEditor.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/OBJDEditor.cs
@@ -467,7 +467,8 @@ namespace FSO.IDE.ResourceBrowser
                 existing.ChunkParent = ActiveObj.Resource.MainIff;
                 existing.ChunkProcessed = true;
                 existing.ChunkID = ActiveObj.OBJ.CatalogStringsID;
-                existing.ChunkLabel = "";
+                existing.ChunkType = "BMP#";
+                existing.ChunkLabel = "Catalog";
             }
 
             Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>

--- a/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/BCONResourceControl.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/BCONResourceControl.cs
@@ -57,7 +57,7 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
             for (int i=0; i<ActiveConst.Constants.Length; i++) { 
                 StringList.Items.Add(new ListViewItem(new string[] {
                     Convert.ToString(i), 
-                    (ActiveConstLabel == null) ? "" : ActiveConstLabel.Entries[i].Label,
+                    (ActiveConstLabel == null) ? "Constant "+i : ActiveConstLabel.Entries[i].Label,
                     ActiveConst.Constants[i].ToString(),
                     (ActiveConstLabel == null) ? "" : ActiveConstLabel.Entries[i].Comment
 
@@ -82,17 +82,25 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
             DownButton.Enabled = enableMod;
             SaveButton.Enabled = enableMod;
 
-            if (ind == -1 || ActiveConstLabel == null)
-            {
-                StringBox.Text = "";
-                NameBox.Text = "";
-                StringBox.Enabled = false;
-                NameBox.Enabled = false;
-            }
-            else
+            if (ActiveConstLabel != null && ind != -1)
             {
                 NameBox.Text = ActiveConstLabel.Entries[ind].Label;
                 StringBox.Text = ActiveConstLabel.Entries[ind].Comment;
+            }
+            else
+            {
+                StringBox.Text = "";
+                if (ind != -1)
+                    NameBox.Text = "Constant " + ind;
+                else
+                    NameBox.Text = "";
+            }
+
+            if (ind == -1/* || ActiveConstLabel == null*/)
+            {
+                
+                StringBox.Enabled = false;
+                NameBox.Enabled = false;
             }
 
             if (enableMod) ValueBox.Value = (short)ActiveConst.Constants[ind];
@@ -109,6 +117,21 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
             }
         }
 
+        private void CheckDeleteLabels()
+        {
+            if (ActiveConstLabel == null)
+                return;
+            if (ActiveConst.Constants.Length <= 0)
+            {
+                Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
+                {
+                    ActiveConstLabel.ChunkParent.FullRemoveChunk(ActiveConstLabel);
+                    Content.Content.Get().Changes.ChunkChanged(ActiveConstLabel);
+                }));
+                ActiveConstLabel = null;
+            }
+        }
+
         private void SaveButton_Click(object sender, EventArgs e)
         {
             OldStr = StringBox.Text;
@@ -120,6 +143,34 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
             {
                 ActiveConst.Constants[ind] = value;
             }, ActiveConst));
+            if (ActiveConstLabel == null)
+            {
+                if (label != "" || comment != "")
+                {
+                    var newLabels = new TRCN();
+                    newLabels.ChunkType = "TRCN";
+                    newLabels.ChunkProcessed = true;
+                    newLabels.ChunkParent = ActiveConst.ChunkParent;
+                    Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
+                    {
+                        newLabels.ChunkID = ActiveConst.ChunkID;
+                        newLabels.ChunkLabel = ActiveConst.ChunkLabel;
+
+                        ActiveConst.ChunkParent.AddChunk(newLabels);
+                        newLabels.AddedByPatch = true;
+                        newLabels.RuntimeInfo = ChunkRuntimeState.Modified;
+                        var newEntries = new TRCNEntry[ActiveConst.Constants.Length];
+                        for(var i=0;i<ActiveConst.Constants.Length;i++)
+                        {
+                            newEntries[i] = new TRCNEntry();
+                            newEntries[i].Comment = "";
+                            newEntries[i].Label = "";
+                        }
+                        newLabels.Entries = newEntries;
+                    }, newLabels));
+                    ActiveConstLabel = newLabels;
+                }
+            }
             if (ActiveConstLabel != null) {
                 Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
                 {
@@ -140,12 +191,44 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
                 c.Add(0);
                 ActiveConst.Constants = c.ToArray();
             }, ActiveConst));
+            if (ActiveConstLabel != null)
+            {
+                Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
+                {
+                    var constEntries = new TRCNEntry[ActiveConst.Constants.Length];
+                    Array.Copy(ActiveConstLabel.Entries, constEntries, ActiveConstLabel.Entries.Length);
+                    var newEntry = new TRCNEntry();
+                    newEntry.Label = "Constant " + (ActiveConst.Constants.Length - 1);
+                    newEntry.Comment = "";
+                    constEntries[ActiveConst.Constants.Length - 1] = newEntry;
+                    ActiveConstLabel.Entries = constEntries;
+                }, ActiveConstLabel));
+            }
             UpdateStrings();
             SelectedStringInd = StringList.Items.Count-1;
         }
 
         private void RemoveButton_Click(object sender, EventArgs e)
         {
+            var ind = SelectedStringInd;
+            Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
+            {
+                var constantList = ActiveConst.Constants.ToList();
+                constantList.RemoveAt(ind);
+                ActiveConst.Constants = constantList.ToArray();
+            }, ActiveConst));
+            if (ActiveConstLabel != null)
+            {
+                Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
+                {
+                    var constantLabelList = ActiveConstLabel.Entries.ToList();
+                    constantLabelList.RemoveAt(ind);
+                    ActiveConstLabel.Entries = constantLabelList.ToArray();
+                }, ActiveConstLabel));
+            }
+            CheckDeleteLabels();
+            UpdateStrings();
+            SelectedStringInd = Math.Max(0, ind - 1);
             /*
             var ind = SelectedStringInd;
             Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
@@ -159,6 +242,22 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
 
         private void UpButton_Click(object sender, EventArgs e)
         {
+            var ind = SelectedStringInd;
+            if (ind == 0) return;
+            Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
+            {
+                var old = ActiveConst.Constants[ind - 1];
+                ActiveConst.Constants[ind - 1] = ActiveConst.Constants[ind];
+                ActiveConst.Constants[ind] = old;
+            }, ActiveConst));
+            if (ActiveConstLabel != null)
+            {
+                var old = ActiveConstLabel.Entries[ind - 1];
+                ActiveConstLabel.Entries[ind - 1] = ActiveConstLabel.Entries[ind];
+                ActiveConstLabel.Entries[ind] = old;
+            }
+            UpdateStrings();
+            SelectedStringInd = ind - 1;
             /*
             var ind = SelectedStringInd;
             if (ind == 0) return;
@@ -175,6 +274,22 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
 
         private void DownButton_Click(object sender, EventArgs e)
         {
+            var ind = SelectedStringInd;
+            if (ind == StringList.Items.Count - 1) return;
+            Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
+            {
+                var old = ActiveConst.Constants[ind + 1];
+                ActiveConst.Constants[ind + 1] = ActiveConst.Constants[ind];
+                ActiveConst.Constants[ind] = old;
+            }, ActiveConst));
+            if (ActiveConstLabel != null)
+            {
+                var old = ActiveConstLabel.Entries[ind + 1];
+                ActiveConstLabel.Entries[ind + 1] = ActiveConstLabel.Entries[ind];
+                ActiveConstLabel.Entries[ind] = old;
+            }
+            UpdateStrings();
+            SelectedStringInd = ind + 1;
             /*
             var ind = SelectedStringInd;
             if (ind == StringList.Items.Count-1) return;

--- a/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/BCONResourceControl.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/BCONResourceControl.cs
@@ -96,7 +96,7 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
                     NameBox.Text = "";
             }
 
-            if (ind == -1/* || ActiveConstLabel == null*/)
+            if (ind == -1)
             {
                 
                 StringBox.Enabled = false;
@@ -229,15 +229,6 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
             CheckDeleteLabels();
             UpdateStrings();
             SelectedStringInd = Math.Max(0, ind - 1);
-            /*
-            var ind = SelectedStringInd;
-            Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
-            {
-                ActiveConst.RemoveString(ind);
-            }, ActiveConst));
-            UpdateStrings();
-            SelectedStringInd = Math.Max(0, ind-1);
-            */
         }
 
         private void UpButton_Click(object sender, EventArgs e)
@@ -258,18 +249,6 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
             }
             UpdateStrings();
             SelectedStringInd = ind - 1;
-            /*
-            var ind = SelectedStringInd;
-            if (ind == 0) return;
-
-            Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
-            {
-                var old = ActiveConst.GetStringEntry(ind - 1);
-                ActiveConst.SwapString(ind, ind - 1);
-            }, ActiveConst));
-            UpdateStrings();
-            SelectedStringInd = ind - 1;
-            */
         }
 
         private void DownButton_Click(object sender, EventArgs e)
@@ -290,18 +269,6 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
             }
             UpdateStrings();
             SelectedStringInd = ind + 1;
-            /*
-            var ind = SelectedStringInd;
-            if (ind == StringList.Items.Count-1) return;
-            
-            Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
-            {
-                var old = ActiveConst.GetStringEntry(ind);
-                ActiveConst.SwapString(ind, ind + 1);
-            }, ActiveConst));
-            UpdateStrings();
-            SelectedStringInd = ind + 1;
-            */
         }
 
         public void SetOBJDAttrs(OBJDSelector[] selectors)

--- a/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/BHAVResourceControl.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/BHAVResourceControl.cs
@@ -81,7 +81,7 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
 
         private void ParamRenameBtn_Click(object sender, EventArgs e)
         {
-            if (ParamList.SelectedIndex == -1/* || ActiveMeta == null*/) return;
+            if (ParamList.SelectedIndex == -1) return;
             int index = ParamList.SelectedIndex;
             var input = new GenericTextInput("Enter a new name for this Parameter.", ParamList.Items[index].ToString());
             input.ShowDialog();
@@ -99,7 +99,7 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
 
         private void LocalRenameBtn_Click(object sender, EventArgs e)
         {
-            if (LocalList.SelectedIndex == -1/* || ActiveMeta == null*/) return;
+            if (LocalList.SelectedIndex == -1) return;
             int index = LocalList.SelectedIndex;
             var input = new GenericTextInput("Enter a new name for this Local.", LocalList.Items[index].ToString());
             input.ShowDialog();
@@ -251,7 +251,6 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
                 newTPRP.ParamNames = newParams;
             }, newTPRP));
             ActiveMeta = newTPRP;
-            //RefreshDisplay();
         }
 
         private void TPRPButton_Click(object sender, EventArgs e)
@@ -265,7 +264,6 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
             bool enableButtons = ParamList.SelectedIndex != -1;
             ParamRemoveBtn.Enabled = enableButtons;
             ParamRenameBtn.Enabled = enableButtons;
-            //ParamRenameBtn.Enabled = enableButtons && ActiveMeta != null;
         }
 
         private void LocalList_SelectedIndexChanged(object sender, EventArgs e)
@@ -273,7 +271,6 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
             bool enableButtons = LocalList.SelectedIndex != -1;
             LocalRemoveBtn.Enabled = enableButtons;
             LocalRenameBtn.Enabled = enableButtons;
-            //LocalRenameBtn.Enabled = enableButtons && ActiveMeta != null;
         }
     }
 }

--- a/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/BHAVResourceControl.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/BHAVResourceControl.cs
@@ -81,11 +81,13 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
 
         private void ParamRenameBtn_Click(object sender, EventArgs e)
         {
-            if (ParamList.SelectedIndex == -1 || ActiveMeta == null) return;
+            if (ParamList.SelectedIndex == -1/* || ActiveMeta == null*/) return;
             int index = ParamList.SelectedIndex;
             var input = new GenericTextInput("Enter a new name for this Parameter.", ParamList.Items[index].ToString());
             input.ShowDialog();
             if (input.DialogResult == DialogResult.OK) {
+                if (ActiveMeta == null)
+                    GenerateTPRP();
                 string name = input.StringResult;
                 Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
                 {
@@ -97,12 +99,14 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
 
         private void LocalRenameBtn_Click(object sender, EventArgs e)
         {
-            if (LocalList.SelectedIndex == -1 || ActiveMeta == null) return;
+            if (LocalList.SelectedIndex == -1/* || ActiveMeta == null*/) return;
             int index = LocalList.SelectedIndex;
             var input = new GenericTextInput("Enter a new name for this Local.", LocalList.Items[index].ToString());
             input.ShowDialog();
             if (input.DialogResult == DialogResult.OK)
             {
+                if (ActiveMeta == null)
+                    GenerateTPRP();
                 string name = input.StringResult;
                 Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
                 {
@@ -152,7 +156,7 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
                     ActiveMeta.LocalNames = newN;
                 }, ActiveMeta));
             }
-
+            CheckRemoveTPRP();
             RefreshDisplay();
         }
 
@@ -196,27 +200,80 @@ namespace FSO.IDE.ResourceBrowser.ResourceEditors
                     ActiveMeta.ParamNames = newN;
                 }, ActiveMeta));
             }
-
+            CheckRemoveTPRP();
             RefreshDisplay();
+        }
+
+        private void CheckRemoveTPRP()
+        {
+            //Delete the metadata chunk if there are no locals or parameters to label.
+            if (ActiveMeta == null)
+                return;
+            if (ActiveChunk.Locals <= 0 && ActiveChunk.Args <= 0)
+            {
+                Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
+                {
+                    ActiveMeta.ChunkParent.FullRemoveChunk(ActiveMeta);
+                    Content.Content.Get().Changes.ChunkChanged(ActiveMeta);
+                }));
+                ActiveMeta = null;
+            }
+        }
+
+        private void GenerateTPRP()
+        {
+            if (ActiveMeta != null) //Just in case? Shouldn't ever be possible though
+                return;
+            var newTPRP = new TPRP();
+            newTPRP.ChunkType = "TPRP";
+            newTPRP.ChunkProcessed = true;
+            newTPRP.ChunkParent = ActiveChunk.ChunkParent;
+            Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
+            {
+                newTPRP.ChunkID = ActiveChunk.ChunkID;
+                newTPRP.ChunkLabel = ActiveChunk.ChunkLabel;
+
+                ActiveChunk.ChunkParent.AddChunk(newTPRP);
+                newTPRP.AddedByPatch = true;
+                newTPRP.RuntimeInfo = ChunkRuntimeState.Modified;
+                var newLocals = new string[ActiveChunk.Locals];
+                //Go through all locals and params and add them with default labels
+                for (var i = 0; i < ActiveChunk.Locals; i++)
+                {
+                    newLocals[i] = "Local " + i;
+                }
+                newTPRP.LocalNames = newLocals;
+                var newParams = new string[ActiveChunk.Args];
+                for (var i = 0; i < ActiveChunk.Args; i++)
+                {
+                    newParams[i] = "Parameter " + i;
+                }
+                newTPRP.ParamNames = newParams;
+            }, newTPRP));
+            ActiveMeta = newTPRP;
+            //RefreshDisplay();
         }
 
         private void TPRPButton_Click(object sender, EventArgs e)
         {
-
+            GenerateTPRP();
+            RefreshDisplay();
         }
 
         private void ParamList_SelectedIndexChanged(object sender, EventArgs e)
         {
             bool enableButtons = ParamList.SelectedIndex != -1;
             ParamRemoveBtn.Enabled = enableButtons;
-            ParamRenameBtn.Enabled = enableButtons && ActiveMeta != null;
+            ParamRenameBtn.Enabled = enableButtons;
+            //ParamRenameBtn.Enabled = enableButtons && ActiveMeta != null;
         }
 
         private void LocalList_SelectedIndexChanged(object sender, EventArgs e)
         {
             bool enableButtons = LocalList.SelectedIndex != -1;
             LocalRemoveBtn.Enabled = enableButtons;
-            LocalRenameBtn.Enabled = enableButtons && ActiveMeta != null;
+            LocalRenameBtn.Enabled = enableButtons;
+            //LocalRenameBtn.Enabled = enableButtons && ActiveMeta != null;
         }
     }
 }

--- a/TSOClient/FSO.IDE/ResourceBrowser/UpgradeEditor.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/UpgradeEditor.cs
@@ -84,7 +84,7 @@ namespace FSO.IDE.ResourceBrowser
             }
             else
             {
-                if (!(Client.UI.Framework.UIScreen.Current is Client.UI.Screens.SandboxGameScreen))
+                if (Content.Content.Get().Upgrades?.ActiveFile != null)
                     UpgradeStatusLabel.Text = "Upgrade editing is not available when online.";
                 else
                     UpgradeStatusLabel.Text = "No Content/upgrades.json file.";

--- a/TSOClient/FSO.IDE/ResourceBrowser/UpgradeEditor.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/UpgradeEditor.cs
@@ -84,7 +84,10 @@ namespace FSO.IDE.ResourceBrowser
             }
             else
             {
-                UpgradeStatusLabel.Text = "Upgrade editing is not available when online.";
+                if (!(Client.UI.Framework.UIScreen.Current is Client.UI.Screens.SandboxGameScreen))
+                    UpgradeStatusLabel.Text = "Upgrade editing is not available when online.";
+                else
+                    UpgradeStatusLabel.Text = "No Content/upgrades.json file.";
                 IffSpecificBox.Enabled = false;
                 ObjectSpecificBox.Enabled = false;
                 CopyButton.Enabled = false;

--- a/TSOClient/tso.client/UI/Panels/UIDebugMenu.cs
+++ b/TSOClient/tso.client/UI/Panels/UIDebugMenu.cs
@@ -24,7 +24,7 @@ namespace FSO.Client.UI.Panels
 
         public UIDebugMenu() : base(UIDialogStyle.Tall, true)
         {
-            SetSize(500, 300);
+            SetSize(500, 340);
             Caption = "Debug Tools";
 
             Position = new Microsoft.Xna.Framework.Vector2(
@@ -184,9 +184,32 @@ namespace FSO.Client.UI.Panels
             };
             Add(cityDCBtn);
 
+            var saveUpgradesBtn = new UIButton();
+            saveUpgradesBtn.Caption = "Export Upgrades";
+            saveUpgradesBtn.Position = new Microsoft.Xna.Framework.Vector2(160, 250);
+            saveUpgradesBtn.Width = 300;
+            saveUpgradesBtn.OnButtonClick += x =>
+            {
+                var content = Content.Content.Get();
+                if (content.Upgrades?.ActiveFile == null)
+                {
+                    UIScreen.GlobalShowAlert(new UIAlertOptions()
+                    {
+                        Message = "No Upgrades File available to export, try joining a server with upgrades."
+                    }, true);
+                    return;
+                }
+                content.Upgrades.SaveJSONTuning();
+                UIScreen.GlobalShowAlert(new UIAlertOptions()
+                {
+                    Message = "Upgrades File was exported to Content/upgrades.json."
+                }, true);
+            };
+            Add(saveUpgradesBtn);
+
             serverNameBox = new UITextBox();
             serverNameBox.X = 50;
-            serverNameBox.Y = 300 - 54;
+            serverNameBox.Y = 340 - 54;
             serverNameBox.SetSize(500 - 100, 25);
             serverNameBox.CurrentText = GlobalSettings.Default.GameEntryUrl;
 


### PR DESCRIPTION
I've been using Volcanic a bunch these past few days and so I've implemented a number of fixes and changes to improve the experience a bit. 

I know it's kind of a big PR, sorry about that, so if there's anything that needs reverting, changing or anything please do let me know!

This is mostly fixes, quality of life changes and implementation of previously placeholder/stubbed features.

Full changelog:

**Fixes:**

- Fixed crash when attempting to save a .piff with added FWAVs/Sound Events.

- Fixed potential crash when attempting to save a .piff with regenerated catalog thumbnails.

- BHAV Editor: Set As First is now fully implemented and shouldn't cause any strange behavior.

- BHAV Editor: BCON Constants are now bounds checked, fixing an exception, and labeled.

**Features:**

- TPRP/Metadata creation has been implemented. You can click on the Generate Metadata button on a BHAV resource or rename any Parameter/Local to generate it.

- TRCN/BCON label creation has been implemented. You can generate this metadata by renaming constants.

- OBJf creation has been implemented, this will happen automatically when you attempt to add a check tree to an entry point.

- UIDebugMenu (Ctrl + F1 window) now has a button to export upgrades from the current server - I know this is not really Volcanic but I thought it was an appropriate spot for it.

**QoL:**

- Upgrade Editor: Now has a more helpful error for not having an upgrades file available in your Content folder.

- Entity Inspector: Added "Open Resource" button, which opens the object editor on the chosen entity.

- Entity Inspector: Can now select multiple entities. Allows deleting and opening multiple resources at once.

- Entity Inspector: Deleting objects now also sends a VMNetDeleteObjectCmd. This way objects can be deleted or sold by a client via Volcanic during online play provided they have the proper permissions.

- Creating new resources in IFFs will now pick the lowest available Chunk ID by default. For BHAVs and BCONs, the minimum Chunk ID now changes depending on whether the resource is Private, Semi-Global or Global.