### PR TITLE
Disabled flags TSO Generic calls.

### DIFF
--- a/TSOClient/tso.simantics/Model/VMGenericTSOCallMode.cs
+++ b/TSOClient/tso.simantics/Model/VMGenericTSOCallMode.cs
@@ -93,6 +93,8 @@ namespace FSO.SimAntics.Model
         FSOReturnNeighborhoodID = 136,
         FSOGoToLotIDTemp01 = 137,
         FSOIsStackObjectTradable = 138,
-        FSOSetStackObjectTransient = 139
+        FSOSetStackObjectTransient = 139,
+        FSOIsStackObjectPendingRoommateDeletion = 140,
+        FSOIsStackObjectAllowedByLotCategory = 141
     }
 }

--- a/TSOClient/tso.simantics/Primitives/VMGenericTSOCall.cs
+++ b/TSOClient/tso.simantics/Primitives/VMGenericTSOCall.cs
@@ -465,6 +465,16 @@ namespace FSO.SimAntics.Primitives
                         }
                         return VMPrimitiveExitCode.GOTO_FALSE;
                     }
+                case VMGenericTSOCallMode.FSOIsStackObjectPendingRoommateDeletion:
+                    {
+                        var gobj = context.StackObject as VMGameObject;
+                        return (gobj != null && gobj.Disabled.HasFlag(VMGameObjectDisableFlags.PendingRoommateDeletion)) ? VMPrimitiveExitCode.GOTO_TRUE : VMPrimitiveExitCode.GOTO_FALSE;
+                    }
+                case VMGenericTSOCallMode.FSOIsStackObjectAllowedByLotCategory:
+                    {
+                        var gobj = context.StackObject as VMGameObject;
+                        return (gobj != null && !gobj.Disabled.HasFlag(VMGameObjectDisableFlags.LotCategoryWrong)) ? VMPrimitiveExitCode.GOTO_TRUE : VMPrimitiveExitCode.GOTO_FALSE;
+                    }
                 default:
                     return VMPrimitiveExitCode.GOTO_TRUE;
             }


### PR DESCRIPTION
+ Adds FSOIsStackObjectPendingRoommateDeletion: Returns true when the Stack Object is pending deletion after their owner moved out of the property.
+ Adds FSOIsStackObjectAllowedByLotCategory: Returns true if the Stack Object is allowed in the current lot category.