### PR TITLE
New FSOCatalogName wildcard for string resources

### DIFF
--- a/TSOClient/tso.simantics/Engine/VMDialogHandler.cs
+++ b/TSOClient/tso.simantics/Engine/VMDialogHandler.cs
@@ -23,7 +23,7 @@ namespace FSO.SimAntics.Engine
         private static string[] valid = {
             "Object", "Me", "TempXL:", "Temp:", "$", "Attribute:", "DynamicStringLocal:", "Local:", "TimeLocal:", "NameLocal:",
             "FixedLocal:", "DynamicObjectName", "MoneyXL:", "JobOffer:", "Job:", "JobDesc:", "Param:", "Neighbor", "\r\n", "ListObject",
-            "CatalogLocal:", "DateLocal:", "ObjectLocal:", "\\n"
+            "CatalogLocal:", "DateLocal:", "ObjectLocal:", "FSOCatalogName", "\\n"
         };
 
         public static void ShowDialog(VMStackFrame context, VMDialogOperand operand, STR source)
@@ -144,6 +144,11 @@ namespace FSO.SimAntics.Engine
                         {
                             switch (cmdString)
                             {
+                                case "FSOCatalogName":
+                                    var fsoCatObj = context.StackObject.MasterDefinition ?? context.StackObject.Object.OBJ;
+                                    var fsoCatName = context.StackObject.Object.Resource.Get<CTSS>(fsoCatObj.CatalogStringsID)?.GetString(0);
+                                    output.Append(fsoCatName ?? context.StackObject.ToString());
+                                    break;
                                 case "Object":
                                 case "DynamicObjectName":
                                     //hack: if stack object doesn't exist and should contain owner's id,


### PR DESCRIPTION
Using `$Object` or `$DynamicObjectName:` in a string resource returns the name of the object. In case of a multi-tile object, this name will be the name of such tile, and not the master object. See example:
![image](https://user-images.githubusercontent.com/45789106/202916398-11729efb-2c74-4cb1-ae61-96917d60e8c4.png)

Leading to a rather unnatural way of naming things for the end user, or even to misleading information:
![image](https://user-images.githubusercontent.com/45789106/202916463-c149c6d7-f0e8-4f8f-a7b8-00533123a7a6.png)

This PR introduces `$FSOCatalogName`, which takes the master definition (if applies) of the object and returns the name as shown in their catalog strings.

Note 1: `$CatalogLocal:` always returns the catalog description, rather than the name.
Note 2: Needs to patch the Salvage interaction and [REDACTED].
