### PR TITLE
Enable nightclub03_00 lot file based on jobType.

### DIFF
--- a/TSOClient/FSO.Server/Servers/Lot/Domain/LotContainer.cs
+++ b/TSOClient/FSO.Server/Servers/Lot/Domain/LotContainer.cs
@@ -652,7 +652,7 @@ namespace FSO.Server.Servers.Lot.Domain
                 var jobPacked = Context.DbId - 0x200;
                 jobLevel = (short)((jobPacked - 1) & 0xF);
                 var jobType = (short)((jobPacked - 1) / 0xF);
-                var randomChance = (jobType > 2 && jobLevel > 6) ? 2 : 1;
+                var randomChance = (jobType == 2 && jobLevel > 6) ? 2 : 1;
                 var lotID = JobMatchmaker.JobGradeToLotGroup[jobType][jobLevel] + (new Random()).Next(randomChance);
 
                 path = Content.Content.Get().GetPath("housedata/blueprints/" + JobMatchmaker.JobXMLName[jobType]


### PR DESCRIPTION
### What
- For DJ / Dancer the `jobType` variable here is always 2 (it would be bad if it was greater than 2 because JobGradeToLotGroup[jobType] of anything beyond 2 isnt defined).
- So we can safely change this check to `jobType == 2` to ensure that DJ and Dancer jobs will have the opportunity to generate a random number either 1 or 2, instead of just 1.