### PR TITLE
TTS on macOS systems

### DIFF
--- a/TSOClient/FSO.Windows/FSO.Windows.csproj
+++ b/TSOClient/FSO.Windows/FSO.Windows.csproj
@@ -93,6 +93,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MacTTSContext.cs" />
     <Compile Include="UITTSContext.cs" />
     <Compile Include="WinFormsClipboard.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/TSOClient/FSO.Windows/MacTTSContext.cs
+++ b/TSOClient/FSO.Windows/MacTTSContext.cs
@@ -1,0 +1,65 @@
+﻿using FSO.Client.UI.Panels;
+using FSO.Common.Utils;
+using Microsoft.Xna.Framework.Audio;
+using System;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace FSO.Windows
+{
+    public class MacTTSContext : ITTSContext
+    {
+        public static MacTTSContext PlatformProvider()
+        {
+            return new MacTTSContext();
+        }
+
+        public MacTTSContext()
+        {
+        }
+
+        public override void Dispose()
+        {
+        }
+
+        public override void Speak(string text, bool gender, int ipitch)
+        {
+            if (string.IsNullOrEmpty(text)) return;
+
+            // Remove double-quotes from text.
+            text = text.Replace("\"", string.Empty);
+            // Remove any 'say' command control sequences.
+            text = Regex.Replace(text, @"\[\[.*?\]\]", string.Empty); 
+
+            // Determine the voice to use based on the gender.
+            // Samantha and Alex are available on most systems.
+            // If not available, it falls back to the default voice.
+            string voice = gender ? "Samantha" : "Alex";
+
+            // Convert pitch from 0-100 scale to 0-127 scale used by 'pbas' command.
+            // Note: negative values are clamped to 0 on macOS, it doesn't allow lower pitch than 0 (the default pitch).
+            int pbas = (int)(ipitch * 1.27);
+
+            // Construct the command to send to 'say'.
+            string command = $"[[pbas {pbas}]] {text}";
+
+            // Create a ProcessStartInfo to specify the 'say' command and arguments.
+            var psi = new ProcessStartInfo("say", $"-v {voice} \"{command}\"")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            try
+            {
+                // Run the 'say' command.
+                Process.Start(psi);
+            }
+            catch (Exception ex)
+            {
+                // Handle exception silently to not disrupt the game if anything happens.
+                Console.WriteLine("Error running 'say' command: " + ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
In this PR, I've made an implementation for TTS on macOS systems. This has been implemented with a new class named MacTTSContext, which extends the ITTSContext interface. 

It runs the `say` (https://ss64.com/osx/say.html) command available on macOS systems, passing in arguments to customize and support most features the Windows implementation has. It runs each TTS execution in a new process (inefficient, but haven't found any other way), so it does not block the game while processing. There has been no noticeable latency in my testing.

I think this implementation is the next best thing to using the native speech synthesizer API on macOS, which can't be used (AFAIK) in the project unless you create a build for macOS. 

### Key points of the implementation:

- Voice Selection: Uses "Alex" for male characters and "Samantha" for female characters. These are default voices on macOS systems and should be available on most of them. If these voices are not available, the system will fall back to the default system voice.
- Pitch Adjustment: Uses the `pbas` command to adjust the pitch of the TTS voice. 
*Note: negative pitch values are not supported by the `pbas` command, so 'deeper' voices aren't supported. You can only make the pitch higher, not lower than the default. The lower-half of the slider in the game settings will only result in the default pitch.*
- Input Sanitization: User input is sanitized before processing to remove any 'say' command sequence injections, ensuring a consistent voice throughout the game.
- Exception Handling: Exceptions during the execution of the 'say' command are silently handled to prevent game disruptions.

Tested on macOS Monterey.

### Preview of both voices in the game
Male voice (Alex): https://streamable.com/2gfkbt
Female voice (Samantha): https://streamable.com/nzf9x5

Please let me know if there are any areas you want me to focus on for further refining or if you have any questions about the implementation. Thanks!!