### PR TITLE
Update JobBalanceTask.cs

### DIFF
--- a/TSOClient/FSO.Server/Servers/Tasks/Domain/JobBalanceTask.cs
+++ b/TSOClient/FSO.Server/Servers/Tasks/Domain/JobBalanceTask.cs
@@ -32,17 +32,17 @@ namespace FSO.Server.Servers.Tasks.Domain
         };
         private static Dictionary<int, int> TypeToTransaction = TransactionToType.ToDictionary(x => x.Value, x => x.Key);
 
-        private float BaseCompletionTime = 270f;
+        private float BaseCompletionTime = 228.96f;
         private static float[] TypeCompletionTimes = new float[]
         {
-            292.21f, //typewriter
-            289.23f, //easel
-            207.73f, //boards
-            299.1f, //jam
-            324.41f, //potion
-            290.47f, //gnome
-            290.6f, //pinata
-            288.13f //telemarketing
+            245f, //typewriter
+            245f, //easel
+            205f, //boards
+            250f, //jam
+            255f, //potion
+            245f, //gnome
+            245f, //pinata
+            245f //telemarketing
         };
 
         private static int[] ToTuningIndex = new int[] //see skillobjects.otf


### PR DESCRIPTION
In the present day boards take ~3:25 to complete, jam ~4:10, potions ~4:15 and the other five single money objects ~4:05. But the values used to balance payouts are way off for all these objects except boards, you can see in the existing code that those are all listed as going for closer to or even above 5 minutes. Something must have happened with the way animations are rendered since chomper did the old timings, but they have been stable at these current times since before I started playing over two years ago.

Why should we be happy with these approximate timings you might ask, since chomper's are listed so exactly? Well exact timings of SMOs are difficult to measure for various reasons such as the human factor of starting and stopping the clock or the fact that the sequence of animations always vary in completion time by a second or two every time. I think that compared to the way off current values the approximate timings I listed above are definitely good enough for rebalancing the SMOs to a point where they will be as good as equal to each other, any imperfection is tiny enough compared to those we have currently due to the big gap between reality and what was listed. And there's no stopping anyone from finding a good method of making more exact time measurements to update them again later. :)

Since the community has become used to the SMO's current payout levels I also proposed to adjust the base completion time downward so that the ratio between it and the average completion time of all 8 objects listed remain the same. This should have the effect that most SMOs continue to pay roughly the same while the outliers - mainly boards but also potions and jam to some extent - are adjusted toward the average.