### PR TITLE
Robot Factory Pay Raise?

### DIFF
--- a/TSOClient/tso.content/Content/Patch/Tuning/oj-robotfactorycontroller.otf
+++ b/TSOClient/tso.content/Content/Patch/Tuning/oj-robotfactorycontroller.otf
@@ -7,6 +7,10 @@
       (10/15/20/25/25/30/30/35/40/45/50)
     - increased roughly 2.5x, gradual scaling
       (30/40/50/60/70/80/90/100/110/120/130)
+
+   UPDATED CHANGES
+   - same baseline but higher pay raise per promotion to be a more viable alternative to restaurant job
+      (30/50/70/90/110/130/150/170/190/210/230)
    -->
 
    <T i="4096" n="Tuning - grade 0">
@@ -31,7 +35,7 @@
       <K i="5" l="StartRoundMaxUnitsBroken" v="1"></K>
       <K i="6" l="%ChanceUnitWillBreakPerCheck" v="5"></K>
       <K i="7" l="SecondsPerBreakCheck" v="115"></K>
-      <K i="8" l="RoundPayoutPerRobot" v="40"></K>
+      <K i="8" l="RoundPayoutPerRobot" v="50"></K>
       <K i="9" l="XPIncAtRoundEnd" v="2"></K>
    </T>
 
@@ -44,7 +48,7 @@
       <K i="5" l="StartRoundMaxUnitsBroken" v="1"></K>
       <K i="6" l="SecondsPerBreakCheck" v="110"></K>
       <K i="7" l="%ChanceUnitWillBreakPerCheck" v="5"></K>
-      <K i="8" l="RoundPayoutPerRobot" v="50"></K>
+      <K i="8" l="RoundPayoutPerRobot" v="70"></K>
       <K i="9" l="XPIncAtRoundEnd" v="2"></K>
    </T>
 
@@ -57,7 +61,7 @@
       <K i="5" l="StartRoundMaxUnitsBroken" v="1"></K>
       <K i="6" l="SecondsPerBreakCheck" v="100"></K>
       <K i="7" l="%ChanceUnitWillBreakPerCheck" v="5"></K>
-      <K i="8" l="RoundPayoutPerRobot" v="60"></K>
+      <K i="8" l="RoundPayoutPerRobot" v="90"></K>
       <K i="9" l="XPIncAtRoundEnd" v="2"></K>
    </T>
 
@@ -70,7 +74,7 @@
       <K i="5" l="StartRoundMaxUnitsBroken" v="1"></K>
       <K i="6" l="SecondsPerBreakCheck" v="95"></K>
       <K i="7" l="%ChanceUnitWillBreakPerCheck" v="5"></K>
-      <K i="8" l="RoundPayoutPerRobot" v="70"></K>
+      <K i="8" l="RoundPayoutPerRobot" v="110"></K>
       <K i="9" l="XPIncAtRoundEnd" v="2"></K>
    </T>
 
@@ -83,7 +87,7 @@
       <K i="5" l="StartRoundMaxUnitsBroken" v="1"></K>
       <K i="6" l="SecondsPerBreakCheck" v="90"></K>
       <K i="7" l="%ChanceUnitWillBreakPerCheck" v="5"></K>
-      <K i="8" l="RoundPayoutPerRobot" v="80"></K>
+      <K i="8" l="RoundPayoutPerRobot" v="130"></K>
       <K i="9" l="XPIncAtRoundEnd" v="2"></K>
    </T>
 
@@ -96,7 +100,7 @@
       <K i="5" l="StartRoundMaxUnitsBroken" v="1"></K>
       <K i="6" l="SecondsPerBreakCheck" v="85"></K>
       <K i="7" l="%ChanceUnitWillBreakPerCheck" v="5"></K>
-      <K i="8" l="RoundPayoutPerRobot" v="90"></K>
+      <K i="8" l="RoundPayoutPerRobot" v="150"></K>
       <K i="9" l="XPIncAtRoundEnd" v="2"></K>
    </T>
 
@@ -109,7 +113,7 @@
       <K i="5" l="StartRoundMaxUnitsBroken" v="1"></K>
       <K i="6" l="SecondsPerBreakCheck" v="80"></K>
       <K i="7" l="%ChanceUnitWillBreakPerCheck" v="5"></K>
-      <K i="8" l="RoundPayoutPerRobot" v="100"></K>
+      <K i="8" l="RoundPayoutPerRobot" v="170"></K>
       <K i="9" l="XPIncAtRoundEnd" v="2"></K>
    </T>
 
@@ -122,7 +126,7 @@
       <K i="5" l="StartRoundMaxUnitsBroken" v="1"></K>
       <K i="6" l="SecondsPerBreakCheck" v="75"></K>
       <K i="7" l="%ChanceUnitWillBreakPerCheck" v="5"></K>
-      <K i="8" l="RoundPayoutPerRobot" v="110"></K>
+      <K i="8" l="RoundPayoutPerRobot" v="190"></K>
       <K i="9" l="XPIncAtRoundEnd" v="2"></K>
    </T>
 
@@ -135,7 +139,7 @@
       <K i="5" l="StartRoundMaxUnitsBroken" v="1"></K>
       <K i="6" l="SecondsPerBreakCheck" v="70"></K>
       <K i="7" l="%ChanceUnitWillBreakPerCheck" v="5"></K>
-      <K i="8" l="RoundPayoutPerRobot" v="120"></K>
+      <K i="8" l="RoundPayoutPerRobot" v="210"></K>
       <K i="9" l="XPIncAtRoundEnd" v="2"></K>
    </T>
 
@@ -148,7 +152,7 @@
       <K i="5" l="StartRoundMaxUnitsBroken" v="1"></K>
       <K i="6" l="SecondsPerBreakCheck" v="60"></K>
       <K i="7" l="%ChanceUnitWillBreakPerCheck" v="5"></K>
-      <K i="8" l="RoundPayoutPerRobot" v="130"></K>
+      <K i="8" l="RoundPayoutPerRobot" v="230"></K>
       <K i="9" l="XPIncAtRoundEnd" v="2"></K>
    </T>
 


### PR DESCRIPTION
The robot factory job is less popular than the restaurant because on average it pays less, and an obvious solution to this is to improve the scaling of the robot payouts to make it a more viable alternative while not going overboard since they are two entirely different types of activities after all.

Diner payouts obviously vary a lot but on average when working with 2 people my experience is that you can earn in tips around $500 to $1000 on the levels 0-2, around $2000 to $3000 on the levels 3-6 and around $3500 to $5000 on the levels 7-10.

In the robot factory when working with two people you usually make anywhere between 10 and 20 robots so let's say 15 as an average to compare. This means with the current payouts on levels 0-2 you make between $450 and $750, on levels 3-6 you make between $900 and $1350, and on levels 7-10 between $1500 and $1950.

As can be seen from this the difference is not that big on the lower levels but on the higher levels you make half of what your restaurant equivalent does. My proposal to make the jobs a little more equal so that more people will choose to work the robots is to keep the baseline at $30 per robot but increase the pay raise between promotions from +10 to +20, resulting in the following changes:

Level 0: $30/robot
Level 1: $50/robot
Level 2: $70/robot
Level 3: $90/robot
Level 4: $110/robot
Level 5: $130/robot
Level 6: $150/robot
Level 7: $170/robot
Level 8: $190/robot
Level 9: $210/robot
Level 10: $230/robot

Working with the same comparison as before this would mean that with a 15 robot average you would make on levels 0-2 between $450 and $1050, on levels 3-6 between $1350 and $2250, and on levels 7-10 between $2550 and $3450. This should make the gap between factory and restaurant less noticeable. If it still sounds low keep in mind that a good factory player on a round without a disastrous amount of repairs usually does 15 as a minimum rather than an average.