### PR TITLE
Add support for Iff 1.0 to Volcanic for SPR# Chunks

### DIFF
--- a/TSOClient/FSO.IDE/Common/SpriteEncoderUtils.cs
+++ b/TSOClient/FSO.IDE/Common/SpriteEncoderUtils.cs
@@ -151,7 +151,7 @@ namespace FSO.IDE.Common
 
                     if (x >= pos.X && x < pos.X + sprite.Width && y >= pos.Y && y < pos.Y + sprite.Height)
                     {
-                        //SPR frames use a grayscale palette                    
+                        //SPR depth frames use a grayscale palette                    
                         if (DepthMapFrame)
                         {
                             // Read this frame as grayscale
@@ -160,7 +160,7 @@ namespace FSO.IDE.Common
                             else col = grayScale.Colors[colorIndex];                            
                         }
                         else
-                        {
+                        { // not depth frame read colors from palette
                             col = sprite.GetPixel((int)(x - pos.X), (int)(y - pos.Y));
                             if (col.A == 0) col = new Microsoft.Xna.Framework.Color(0xFF, 0xFF, 0x00, 0x00);
                             // ** no alpha component!
@@ -183,7 +183,6 @@ namespace FSO.IDE.Common
 
                     index += 4;
                 }
-
             }
 
             for (int i = 0; i < 3; i++)

--- a/TSOClient/FSO.IDE/Common/SpriteEncoderUtils.cs
+++ b/TSOClient/FSO.IDE/Common/SpriteEncoderUtils.cs
@@ -1,9 +1,15 @@
 ﻿using FSO.Files.Formats.IFF.Chunks;
 using Microsoft.Xna.Framework;
 using SimplePaletteQuantizer.Helpers;
+using SimplePaletteQuantizer.Quantizers.DistinctSelection;
+using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace FSO.IDE.Common
 {
@@ -47,6 +53,16 @@ namespace FSO.IDE.Common
         public static System.Drawing.Image[] GetPixelAlpha(SPR2Frame sprite, int tWidth, int tHeight)
         {
             return GetPixelAlpha(sprite, tWidth, tHeight, sprite.Position);
+        }
+        /// <summary>
+        /// Generates windows bitmaps for the appearance of this sprite.
+        /// </summary>
+        /// <param name="tWidth"></param>
+        /// <param name="tHeight"></param>
+        /// <returns>Array of three images, [Color, Alpha, Depth].</returns>
+        public static System.Drawing.Image[] GetPixelAlpha(SPRFrame sprite, int tWidth, int tHeight, bool DepthMapFrame = false)
+        {
+            return GetPixelAlpha(sprite, tWidth, tHeight, new Vector2(0), DepthMapFrame);
         }
 
         public static System.Drawing.Image[] GetPixelAlpha(SPR2Frame sprite, int tWidth, int tHeight, Vector2 pos)
@@ -100,6 +116,74 @@ namespace FSO.IDE.Common
 
                     index += 4;
                 }
+            }
+
+            for (int i = 0; i < 3; i++)
+            {
+                Marshal.Copy(data[i], 0, locks[i].Scan0, data[i].Length);
+                result[i].UnlockBits(locks[i]);
+            }
+
+            return result;
+        }
+        public static System.Drawing.Image[] GetPixelAlpha(SPRFrame sprite, int tWidth, int tHeight, Vector2 pos, bool DepthMapFrame = false)
+        {
+            var grayScale = default(PALT);
+            if (DepthMapFrame) grayScale = PALT.Greyscale;
+
+            var result = new System.Drawing.Bitmap[3];
+            var locks = new BitmapData[3];
+            var data = new byte[3][];
+            for (int i = 0; i < 3; i++)
+            {
+                result[i] = new System.Drawing.Bitmap(tWidth, tHeight, PixelFormat.Format24bppRgb);
+                locks[i] = result[i].LockBits(new System.Drawing.Rectangle(0, 0, tWidth, tHeight), ImageLockMode.ReadWrite, PixelFormat.Format32bppRgb);
+                data[i] = new byte[locks[i].Stride * locks[i].Height];
+            }
+
+            int index = 0;
+            for (int y = 0; y < tHeight; y++)
+            {
+                for (int x = 0; x < tWidth; x++)
+                {
+                    Microsoft.Xna.Framework.Color col;
+                    byte depth = 255;
+
+                    if (x >= pos.X && x < pos.X + sprite.Width && y >= pos.Y && y < pos.Y + sprite.Height)
+                    {
+                        //SPR frames use a grayscale palette                    
+                        if (DepthMapFrame)
+                        {
+                            // Read this frame as grayscale
+                            byte colorIndex = sprite.Indices[(y * sprite.Width + x)];
+                            if(colorIndex == 0) col = new Microsoft.Xna.Framework.Color(0xFF, 0xFF, 0x00, 0x00);
+                            else col = grayScale.Colors[colorIndex];                            
+                        }
+                        else
+                        {
+                            col = sprite.GetPixel((int)(x - pos.X), (int)(y - pos.Y));
+                            if (col.A == 0) col = new Microsoft.Xna.Framework.Color(0xFF, 0xFF, 0x00, 0x00);
+                            // ** no alpha component!
+                        }
+                    }
+                    else
+                    {
+                        col = new Microsoft.Xna.Framework.Color(0xFF, 0xFF, 0x00, 0x00);
+                    }                    
+
+                    data[0][index] = col.B;
+                    data[0][index + 1] = col.G;
+                    data[0][index + 2] = col.R;
+                    data[0][index + 3] = 255;
+
+                    data[1][index] = col.A;
+                    data[1][index + 1] = col.A;
+                    data[1][index + 2] = col.A;
+                    data[1][index + 3] = 255;
+
+                    index += 4;
+                }
+
             }
 
             for (int i = 0; i < 3; i++)

--- a/TSOClient/FSO.IDE/MainWindow.Designer.cs
+++ b/TSOClient/FSO.IDE/MainWindow.Designer.cs
@@ -56,6 +56,8 @@
             this.saveGlobalscsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.avatarToolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openExternalIffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.iFFFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sPFFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fieldEncodingReverserToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.windowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hideAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -78,9 +80,10 @@
             this.ChangesView = new System.Windows.Forms.TreeView();
             this.BrowserTab = new System.Windows.Forms.TabPage();
             this.NewOBJButton = new System.Windows.Forms.Button();
-            this.InspectorTab = new System.Windows.Forms.TabPage();
             this.Browser = new FSO.IDE.ObjectBrowser();
+            this.InspectorTab = new System.Windows.Forms.TabPage();
             this.entityInspector1 = new FSO.IDE.EntityInspector();
+            this.bothToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.UtilityTabs.SuspendLayout();
             this.OverviewTab.SuspendLayout();
@@ -170,7 +173,7 @@
             this.openExternalIffToolStripMenuItem,
             this.fieldEncodingReverserToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
             this.toolsToolStripMenuItem.Text = "Tools";
             // 
             // dataServiceEditorToolStripMenuItem
@@ -191,7 +194,7 @@
             // saveGlobalscsToolStripMenuItem
             // 
             this.saveGlobalscsToolStripMenuItem.Name = "saveGlobalscsToolStripMenuItem";
-            this.saveGlobalscsToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
+            this.saveGlobalscsToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
             this.saveGlobalscsToolStripMenuItem.Text = "Generate AOT Sources (.cs)";
             this.saveGlobalscsToolStripMenuItem.Click += new System.EventHandler(this.saveGlobalscsToolStripMenuItem_Click);
             // 
@@ -204,10 +207,27 @@
             // 
             // openExternalIffToolStripMenuItem
             // 
+            this.openExternalIffToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.iFFFileToolStripMenuItem,
+            this.sPFFileToolStripMenuItem,
+            this.bothToolStripMenuItem});
             this.openExternalIffToolStripMenuItem.Name = "openExternalIffToolStripMenuItem";
             this.openExternalIffToolStripMenuItem.Size = new System.Drawing.Size(199, 22);
-            this.openExternalIffToolStripMenuItem.Text = "Open External Iff...";
-            this.openExternalIffToolStripMenuItem.Click += new System.EventHandler(this.openExternalIffToolStripMenuItem_Click);
+            this.openExternalIffToolStripMenuItem.Text = "Open External Iff/Spf...";
+            // 
+            // iFFFileToolStripMenuItem
+            // 
+            this.iFFFileToolStripMenuItem.Name = "iFFFileToolStripMenuItem";
+            this.iFFFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.iFFFileToolStripMenuItem.Text = "Iff File...";
+            this.iFFFileToolStripMenuItem.Click += new System.EventHandler(this.openExternalIffToolStripMenuItem_Click);
+            // 
+            // sPFFileToolStripMenuItem
+            // 
+            this.sPFFileToolStripMenuItem.Name = "sPFFileToolStripMenuItem";
+            this.sPFFileToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.sPFFileToolStripMenuItem.Text = "Spf File...";
+            this.sPFFileToolStripMenuItem.Click += new System.EventHandler(this.sPFFileToolStripMenuItem_Click);
             // 
             // fieldEncodingReverserToolStripMenuItem
             // 
@@ -229,14 +249,14 @@
             // hideAllToolStripMenuItem
             // 
             this.hideAllToolStripMenuItem.Name = "hideAllToolStripMenuItem";
-            this.hideAllToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
+            this.hideAllToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.hideAllToolStripMenuItem.Text = "Hide All";
             this.hideAllToolStripMenuItem.Click += new System.EventHandler(this.hideAllToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(113, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(177, 6);
             // 
             // helpToolStripMenuItem
             // 
@@ -462,6 +482,16 @@
             this.NewOBJButton.UseVisualStyleBackColor = true;
             this.NewOBJButton.Click += new System.EventHandler(this.NewOBJButton_Click);
             // 
+            // Browser
+            // 
+            this.Browser.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.Browser.Location = new System.Drawing.Point(3, 3);
+            this.Browser.Name = "Browser";
+            this.Browser.Size = new System.Drawing.Size(724, 452);
+            this.Browser.TabIndex = 0;
+            // 
             // InspectorTab
             // 
             this.InspectorTab.Controls.Add(this.entityInspector1);
@@ -473,16 +503,6 @@
             this.InspectorTab.Text = "VMEntity Inspector";
             this.InspectorTab.UseVisualStyleBackColor = true;
             // 
-            // Browser
-            // 
-            this.Browser.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.Browser.Location = new System.Drawing.Point(3, 3);
-            this.Browser.Name = "Browser";
-            this.Browser.Size = new System.Drawing.Size(724, 452);
-            this.Browser.TabIndex = 0;
-            // 
             // entityInspector1
             // 
             this.entityInspector1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -492,6 +512,13 @@
             this.entityInspector1.Name = "entityInspector1";
             this.entityInspector1.Size = new System.Drawing.Size(724, 452);
             this.entityInspector1.TabIndex = 0;
+            // 
+            // bothToolStripMenuItem
+            // 
+            this.bothToolStripMenuItem.Name = "bothToolStripMenuItem";
+            this.bothToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.bothToolStripMenuItem.Text = "Both...";
+            this.bothToolStripMenuItem.Click += new System.EventHandler(this.bothToolStripMenuItem_Click);
             // 
             // MainWindow
             // 
@@ -560,5 +587,8 @@
         private System.Windows.Forms.ToolStripMenuItem avatarToolToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openExternalIffToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem fieldEncodingReverserToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem iFFFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem sPFFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem bothToolStripMenuItem;
     }
 }

--- a/TSOClient/FSO.IDE/MainWindow.cs
+++ b/TSOClient/FSO.IDE/MainWindow.cs
@@ -1,28 +1,18 @@
-﻿using FSO.Client;
-using FSO.Content;
+﻿using FSO.Content;
 using FSO.Files.Formats.IFF;
 using FSO.Files.Formats.IFF.Chunks;
-using FSO.Files.RC;
 using FSO.IDE.Common;
 using FSO.IDE.ContentEditors;
 using FSO.IDE.Managers;
-using FSO.IDE.ResourceBrowser.SelectorDialogs;
+using FSO.IDE.ResourceBrowser;
 using FSO.IDE.Utils.FormatReverse;
 using FSO.SimAntics;
-using FSO.SimAntics.JIT.Translation.CSharp;
 using FSO.SimAntics.NetPlay.Model.Commands;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;
 
 namespace FSO.IDE
 {

--- a/TSOClient/FSO.IDE/ResourceBrowser/IFFResComponent.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/IFFResComponent.cs
@@ -28,6 +28,7 @@ namespace FSO.IDE.ResourceBrowser
             { typeof(CTSS), typeof(STRResourceControl) },
             { typeof(TTAB), typeof(TTABResourceControl) },
             { typeof(SPR2), typeof(SPR2ResourceControl) },
+            { typeof(SPR), typeof(SPRResourceControl) },
             { typeof(BCON), typeof(BCONResourceControl) },
             { typeof(SLOT), typeof(SLOTResourceControl) },
             { typeof(FCNS), typeof(STRResourceControl) },
@@ -43,6 +44,7 @@ namespace FSO.IDE.ResourceBrowser
             typeof(SLOT),
             typeof(CTSS),
             typeof(SPR2),
+            typeof(SPR),
             typeof(FCNS),
             typeof(OTFFile)
         };
@@ -54,7 +56,8 @@ namespace FSO.IDE.ResourceBrowser
             "Constants",
             "SLOTs",
             "Catalog Strings",
-            "Sprites",
+            "Sprites (SPR2)",
+            "Sprites (SPR#)",
             "Simulator Constants",
             "Tuning (OTF)"
         };

--- a/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/SPRResourceControl.Designer.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/SPRResourceControl.Designer.cs
@@ -1,0 +1,283 @@
+﻿namespace FSO.IDE.ResourceBrowser.ResourceEditors
+{
+    partial class SPRResourceControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.ModeCombo = new System.Windows.Forms.ComboBox();
+            this.PreviewLabel = new System.Windows.Forms.Label();
+            this.SPRBox3 = new System.Windows.Forms.PictureBox();
+            this.SPRBox2 = new System.Windows.Forms.PictureBox();
+            this.SPRBox1 = new System.Windows.Forms.PictureBox();
+            this.FrameList = new System.Windows.Forms.ListBox();
+            this.FramesLabel = new System.Windows.Forms.Label();
+            this.NewButton = new System.Windows.Forms.Button();
+            this.ImportButton = new System.Windows.Forms.Button();
+            this.ExportButton = new System.Windows.Forms.Button();
+            this.DeleteButton = new System.Windows.Forms.Button();
+            this.ExportAll = new System.Windows.Forms.Button();
+            this.ImportAll = new System.Windows.Forms.Button();
+            this.AutoZooms = new System.Windows.Forms.CheckBox();
+            this.SheetImport = new System.Windows.Forms.Button();
+            this.FramesButton = new System.Windows.Forms.Button();
+            this.SPRSelector = new FSO.IDE.ResourceBrowser.OBJDSelectorControl();
+            ((System.ComponentModel.ISupportInitialize)(this.SPRBox3)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.SPRBox2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.SPRBox1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // ModeCombo
+            // 
+            this.ModeCombo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.ModeCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.ModeCombo.FormattingEnabled = true;
+            this.ModeCombo.Items.AddRange(new object[] {
+            "Color",
+            "Alpha",
+            "Z-Buffer"});
+            this.ModeCombo.Location = new System.Drawing.Point(3, 431);
+            this.ModeCombo.Name = "ModeCombo";
+            this.ModeCombo.Size = new System.Drawing.Size(250, 21);
+            this.ModeCombo.TabIndex = 3;
+            this.ModeCombo.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);
+            // 
+            // PreviewLabel
+            // 
+            this.PreviewLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.PreviewLabel.AutoSize = true;
+            this.PreviewLabel.Location = new System.Drawing.Point(3, 21);
+            this.PreviewLabel.Name = "PreviewLabel";
+            this.PreviewLabel.Size = new System.Drawing.Size(48, 13);
+            this.PreviewLabel.TabIndex = 4;
+            this.PreviewLabel.Text = "Preview:";
+            // 
+            // SPRBox3
+            // 
+            this.SPRBox3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.SPRBox3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.SPRBox3.Location = new System.Drawing.Point(219, 325);
+            this.SPRBox3.Name = "SPRBox3";
+            this.SPRBox3.Size = new System.Drawing.Size(34, 100);
+            this.SPRBox3.TabIndex = 2;
+            this.SPRBox3.TabStop = false;
+            // 
+            // SPRBox2
+            // 
+            this.SPRBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.SPRBox2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.SPRBox2.Location = new System.Drawing.Point(145, 229);
+            this.SPRBox2.Name = "SPRBox2";
+            this.SPRBox2.Size = new System.Drawing.Size(68, 196);
+            this.SPRBox2.TabIndex = 1;
+            this.SPRBox2.TabStop = false;
+            // 
+            // SPRBox1
+            // 
+            this.SPRBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.SPRBox1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.SPRBox1.Location = new System.Drawing.Point(3, 37);
+            this.SPRBox1.Name = "SPRBox1";
+            this.SPRBox1.Size = new System.Drawing.Size(136, 388);
+            this.SPRBox1.TabIndex = 0;
+            this.SPRBox1.TabStop = false;
+            // 
+            // FrameList
+            // 
+            this.FrameList.FormattingEnabled = true;
+            this.FrameList.IntegralHeight = false;
+            this.FrameList.Location = new System.Drawing.Point(269, 37);
+            this.FrameList.Name = "FrameList";
+            this.FrameList.Size = new System.Drawing.Size(149, 305);
+            this.FrameList.TabIndex = 5;
+            this.FrameList.SelectedIndexChanged += new System.EventHandler(this.FrameList_SelectedIndexChanged);
+            // 
+            // FramesLabel
+            // 
+            this.FramesLabel.AutoSize = true;
+            this.FramesLabel.Location = new System.Drawing.Point(266, 21);
+            this.FramesLabel.Name = "FramesLabel";
+            this.FramesLabel.Size = new System.Drawing.Size(55, 13);
+            this.FramesLabel.TabIndex = 6;
+            this.FramesLabel.Text = "Rotations:";
+            // 
+            // NewButton
+            // 
+            this.NewButton.Enabled = false;
+            this.NewButton.Location = new System.Drawing.Point(424, 37);
+            this.NewButton.Name = "NewButton";
+            this.NewButton.Size = new System.Drawing.Size(75, 23);
+            this.NewButton.TabIndex = 7;
+            this.NewButton.Text = "New";
+            this.NewButton.UseVisualStyleBackColor = true;
+            this.NewButton.Click += new System.EventHandler(this.NewButton_Click);
+            // 
+            // ImportButton
+            // 
+            this.ImportButton.Enabled = false;
+            this.ImportButton.Location = new System.Drawing.Point(424, 66);
+            this.ImportButton.Name = "ImportButton";
+            this.ImportButton.Size = new System.Drawing.Size(75, 23);
+            this.ImportButton.TabIndex = 8;
+            this.ImportButton.Text = "Import";
+            this.ImportButton.UseVisualStyleBackColor = true;
+            this.ImportButton.Click += new System.EventHandler(this.ImportButton_Click);
+            // 
+            // ExportButton
+            // 
+            this.ExportButton.Location = new System.Drawing.Point(424, 95);
+            this.ExportButton.Name = "ExportButton";
+            this.ExportButton.Size = new System.Drawing.Size(75, 23);
+            this.ExportButton.TabIndex = 9;
+            this.ExportButton.Text = "Export";
+            this.ExportButton.UseVisualStyleBackColor = true;
+            this.ExportButton.Click += new System.EventHandler(this.ExportButton_Click);
+            // 
+            // DeleteButton
+            // 
+            this.DeleteButton.Enabled = false;
+            this.DeleteButton.Location = new System.Drawing.Point(424, 124);
+            this.DeleteButton.Name = "DeleteButton";
+            this.DeleteButton.Size = new System.Drawing.Size(75, 23);
+            this.DeleteButton.TabIndex = 10;
+            this.DeleteButton.Text = "Delete";
+            this.DeleteButton.UseVisualStyleBackColor = true;
+            this.DeleteButton.Click += new System.EventHandler(this.DeleteButton_Click);
+            // 
+            // ExportAll
+            // 
+            this.ExportAll.Location = new System.Drawing.Point(269, 377);
+            this.ExportAll.Name = "ExportAll";
+            this.ExportAll.Size = new System.Drawing.Size(149, 23);
+            this.ExportAll.TabIndex = 11;
+            this.ExportAll.Text = "Export All";
+            this.ExportAll.UseVisualStyleBackColor = true;
+            this.ExportAll.Click += new System.EventHandler(this.ExportAll_Click);
+            // 
+            // ImportAll
+            // 
+            this.ImportAll.Enabled = false;
+            this.ImportAll.Location = new System.Drawing.Point(269, 348);
+            this.ImportAll.Name = "ImportAll";
+            this.ImportAll.Size = new System.Drawing.Size(149, 23);
+            this.ImportAll.TabIndex = 12;
+            this.ImportAll.Text = "Import All";
+            this.ImportAll.UseVisualStyleBackColor = true;
+            this.ImportAll.Click += new System.EventHandler(this.ImportAll_Click);
+            // 
+            // AutoZooms
+            // 
+            this.AutoZooms.AutoSize = true;
+            this.AutoZooms.Checked = true;
+            this.AutoZooms.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.AutoZooms.Location = new System.Drawing.Point(250, 0);
+            this.AutoZooms.Name = "AutoZooms";
+            this.AutoZooms.Size = new System.Drawing.Size(249, 17);
+            this.AutoZooms.TabIndex = 13;
+            this.AutoZooms.Text = "Automatically Generate Medium and Far Zooms";
+            this.AutoZooms.UseVisualStyleBackColor = true;
+            this.AutoZooms.CheckedChanged += new System.EventHandler(this.AutoZooms_CheckedChanged);
+            // 
+            // SheetImport
+            // 
+            this.SheetImport.Enabled = false;
+            this.SheetImport.Location = new System.Drawing.Point(424, 348);
+            this.SheetImport.Name = "SheetImport";
+            this.SheetImport.Size = new System.Drawing.Size(75, 52);
+            this.SheetImport.TabIndex = 15;
+            this.SheetImport.Text = "Import from TGA Sheet";
+            this.SheetImport.UseVisualStyleBackColor = true;
+            this.SheetImport.Click += new System.EventHandler(this.SheetImport_Click);
+            // 
+            // FramesButton
+            // 
+            this.FramesButton.Location = new System.Drawing.Point(424, 153);
+            this.FramesButton.Name = "FramesButton";
+            this.FramesButton.Size = new System.Drawing.Size(75, 23);
+            this.FramesButton.TabIndex = 16;
+            this.FramesButton.Text = "Frames";
+            this.FramesButton.UseVisualStyleBackColor = true;
+            this.FramesButton.Click += new System.EventHandler(this.FramesButton_Click);
+            // 
+            // SPRSelector
+            // 
+            this.SPRSelector.Location = new System.Drawing.Point(269, 406);
+            this.SPRSelector.Name = "SPRSelector";
+            this.SPRSelector.Size = new System.Drawing.Size(230, 46);
+            this.SPRSelector.TabIndex = 14;
+            // 
+            // SPRResourceControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.FramesButton);
+            this.Controls.Add(this.SheetImport);
+            this.Controls.Add(this.SPRSelector);
+            this.Controls.Add(this.AutoZooms);
+            this.Controls.Add(this.ImportAll);
+            this.Controls.Add(this.ExportAll);
+            this.Controls.Add(this.DeleteButton);
+            this.Controls.Add(this.ExportButton);
+            this.Controls.Add(this.ImportButton);
+            this.Controls.Add(this.NewButton);
+            this.Controls.Add(this.FramesLabel);
+            this.Controls.Add(this.FrameList);
+            this.Controls.Add(this.PreviewLabel);
+            this.Controls.Add(this.ModeCombo);
+            this.Controls.Add(this.SPRBox3);
+            this.Controls.Add(this.SPRBox2);
+            this.Controls.Add(this.SPRBox1);
+            this.Name = "SPRResourceControl";
+            this.Size = new System.Drawing.Size(502, 455);
+            ((System.ComponentModel.ISupportInitialize)(this.SPRBox3)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.SPRBox2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.SPRBox1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.PictureBox SPRBox1;
+        private System.Windows.Forms.PictureBox SPRBox2;
+        private System.Windows.Forms.PictureBox SPRBox3;
+        private System.Windows.Forms.ComboBox ModeCombo;
+        private System.Windows.Forms.Label PreviewLabel;
+        private System.Windows.Forms.ListBox FrameList;
+        private System.Windows.Forms.Label FramesLabel;
+        private System.Windows.Forms.Button NewButton;
+        private System.Windows.Forms.Button ImportButton;
+        private System.Windows.Forms.Button ExportButton;
+        private System.Windows.Forms.Button DeleteButton;
+        private System.Windows.Forms.Button ExportAll;
+        private System.Windows.Forms.Button ImportAll;
+        private System.Windows.Forms.CheckBox AutoZooms;
+        private OBJDSelectorControl SPRSelector;
+        private System.Windows.Forms.Button SheetImport;
+        private System.Windows.Forms.Button FramesButton;
+    }
+}

--- a/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/SPRResourceControl.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/SPRResourceControl.cs
@@ -1,0 +1,287 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using FSO.Content;
+using FSO.Files.Formats.IFF;
+using FSO.Files.Formats.IFF.Chunks;
+using System.IO;
+using System.Drawing.Imaging;
+using System.Threading;
+using System.Runtime.InteropServices;
+using FSO.IDE.Common;
+using System.Reflection;
+
+namespace FSO.IDE.ResourceBrowser.ResourceEditors
+{
+    public partial class SPRResourceControl : UserControl, IResourceControl
+    {
+        private static bool FramesMode;
+
+        public SPR GraphicChunk;
+        public GameIffResource ActiveIff;
+
+        public Image[][] Graphics;
+
+        public SPRResourceControl()
+        {
+            InitializeComponent();
+            ModeCombo.SelectedIndex = 0;
+        }
+
+        public void SetActiveObject(GameObject obj)
+        {
+        }
+
+        public void SetActiveResource(IffChunk chunk, GameIffResource res)
+        {
+            GraphicChunk = (SPR)chunk;
+            ActiveIff = res;
+
+            FrameList.Items.Clear();
+            if (!FramesMode)
+            {
+                for (int i = 0; i < (GraphicChunk.Frames.Count / 2) / 3; i++)
+                {
+                    FrameList.Items.Add("Rotation " + i);
+                }
+                FramesButton.Text = "Frames";
+                FramesLabel.Text = "Rotations:";
+            }
+            else
+            {
+                for (int i = 0; i < GraphicChunk.Frames.Count; i++)
+                {
+                    FrameList.Items.Add("Frame " + i);
+                }
+                FramesButton.Text = "Rotations";
+                FramesLabel.Text = "Frames:";
+            }            
+
+            bool hasFrames = (FrameList.Items.Count > 0);
+            Graphics = null;
+            if (hasFrames) FrameList.SelectedIndex = 0;
+            else
+            {
+                SPRBox1.Image = null;
+                SPRBox2.Image = null;
+                SPRBox3.Image = null;
+            }
+            DeleteButton.Enabled = false;// hasFrames;
+            ImportButton.Enabled = false;// hasFrames;
+            ExportButton.Enabled = hasFrames;
+            ImportAll.Enabled = false;// hasFrames;
+            ExportAll.Enabled = hasFrames;
+        }
+
+        public void SetOBJDAttrs(OBJDSelector[] selectors)
+        {
+            SPRSelector.SetSelectors(null, GraphicChunk, selectors);
+        }
+
+        void RenderResourceModification(Image[][] Graphics, int index, bool depthFrame = false) => 
+            Content.Content.Get().Changes.BlockingResMod(new ResAction(() =>
+            {
+                int step = (GraphicChunk.Frames.Count / 2) / 3;
+                if (depthFrame)
+                    index += GraphicChunk.Frames.Count / 2;
+                if (FramesMode)
+                    step = 0;
+
+                Graphics[0] = SpriteEncoderUtils.GetPixelAlpha(GraphicChunk.Frames.ElementAt(index), 136, 384, depthFrame);
+                Graphics[1] = SpriteEncoderUtils.GetPixelAlpha(GraphicChunk.Frames.ElementAt(index + step), 68, 192, depthFrame);
+                Graphics[2] = SpriteEncoderUtils.GetPixelAlpha(GraphicChunk.Frames.ElementAt(index + (step * 2)), 34, 96, depthFrame);
+            }, GraphicChunk, false));
+
+        public void UpdateGraphics()
+        {
+            int index = FrameList.SelectedIndex;
+            Graphics = new Image[3][];
+            
+            bool depthFrame = ModeCombo.SelectedIndex == 2;
+            RenderResourceModification(Graphics, index, depthFrame);
+        }
+
+        public void SetDisplay()
+        {
+            int mode = ModeCombo.SelectedIndex;
+            if (mode == -1 || Graphics == null || Graphics[0] == null) return;
+            if (mode == 2) mode = 0; // workaround for SPR using separate depth frames
+            SPRBox1.Image = Graphics[0][mode];
+            SPRBox2.Image = Graphics[1][mode];
+            SPRBox3.Image = Graphics[2][mode];
+        }
+
+        public void ExportSPR(int index, string path)
+        {
+            var gfx = new Image[3][];
+
+            var iffname = ActiveIff.MainIff.Filename;
+            var extension = iffname.LastIndexOf('.');
+            if (extension != -1) iffname = iffname.Substring(0, extension);
+
+            var baseName = Path.Combine(path, iffname + "_spr1" + GraphicChunk.ChunkID + "_r" + index);
+
+            RenderResourceModification(gfx, index, false);
+            gfx[0][0].Save(baseName + "_near" + "_color.bmp", ImageFormat.Bmp);
+            gfx[0][1].Save(baseName + "_near" + "_alpha.bmp", ImageFormat.Bmp);
+            if (!AutoZooms.Checked)
+            {
+                gfx[1][0].Save(baseName + "_med" + "_color.bmp", ImageFormat.Bmp);
+                gfx[1][1].Save(baseName + "_med" + "_alpha.bmp", ImageFormat.Bmp);
+                gfx[2][0].Save(baseName + "_far" + "_color.bmp", ImageFormat.Bmp);
+                gfx[2][1].Save(baseName + "_far" + "_alpha.bmp", ImageFormat.Bmp);
+            }
+            RenderResourceModification(gfx, index, true);
+            gfx[0][0].Save(baseName + "_near" + "_depth.bmp", ImageFormat.Bmp);
+            if (!AutoZooms.Checked)
+            {
+                gfx[1][0].Save(baseName + "_med" + "_depth.bmp", ImageFormat.Bmp);
+                gfx[2][0].Save(baseName + "_far" + "_depth.bmp", ImageFormat.Bmp);
+            }
+        }
+
+        private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            int mode = ModeCombo.SelectedIndex;
+            if (GraphicChunk != default && mode != 1)
+                UpdateGraphics(); // Ineffective for the Alpha channel since it doesn't exist
+            SetDisplay();
+        }
+
+        private void FrameList_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            UpdateGraphics();
+            SetDisplay();
+        }
+
+        private void ExportButton_Click(object sender, EventArgs e)
+        {
+            var dialog = new FolderBrowserDialog();
+            dialog.ShowNewFolderButton = true;
+            dialog.Description = "Choose a folder to export this Sprite Rotation to.";
+            FolderBrowse(dialog);
+
+            if (dialog.SelectedPath == "") return;
+            var path = dialog.SelectedPath;
+            ExportSPR(FrameList.SelectedIndex, path);
+        }
+
+        private void ExportAll_Click(object sender, EventArgs e)
+        {
+            var dialog = new FolderBrowserDialog();
+            dialog.ShowNewFolderButton = true;
+            dialog.Description = "Choose a folder to export all Sprite Rotations to.";
+            FolderBrowse(dialog);
+
+            if (dialog.SelectedPath == "") return;
+            var path = dialog.SelectedPath;
+
+            for (int i = 0; i < FrameList.Items.Count; i++)
+                ExportSPR(i, path);
+        }
+
+        private void FolderBrowse(FolderBrowserDialog dialog)
+        {
+            // ༼ つ ◕_◕ ༽つ IMPEACH STAThread ༼ つ ◕_◕ ༽つ
+            var wait = new AutoResetEvent(false);
+            var thread = new Thread(() => {
+                dialog.ShowDialog();
+                wait.Set();
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            wait.WaitOne();
+            return;
+        }
+
+        private void AutoZooms_CheckedChanged(object sender, EventArgs e)
+        {
+
+        }
+
+        private void ImportAll_Click(object sender, EventArgs e)
+        {
+            var dialog = new FolderBrowserDialog();
+            dialog.Description = "Choose a folder to export all Sprite Rotations from.";
+            FolderBrowse(dialog);
+
+            if (dialog.SelectedPath == "") return;
+            ImportSprites(dialog.SelectedPath, -1);
+        }
+
+        private void ImportSprites(string path, int targrot)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void ReplaceSprite(Bitmap[] bmps, int frame)
+        {
+            
+        }
+
+        private void NewRotation(int num)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void DeleteRotation(int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void ImportButton_Click(object sender, EventArgs e)
+        {
+            var dialog = new FolderBrowserDialog();
+            dialog.Description = "Choose a folder to export a Sprite Rotation from.";
+            FolderBrowse(dialog);
+
+            if (dialog.SelectedPath == "") return;
+            ImportSprites(dialog.SelectedPath, FrameList.SelectedIndex);
+        }
+
+        private void NewButton_Click(object sender, EventArgs e)
+        {
+            throw new NotImplementedException();
+            NewRotation(1);
+        }
+
+        private void DeleteButton_Click(object sender, EventArgs e)
+        {
+            throw new NotImplementedException();
+            if (FrameList.SelectedIndex == -1) return;
+            DeleteRotation(FrameList.SelectedIndex);
+        }
+
+        private void SheetImport_Click(object sender, EventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        private bool FileBrowse(FileDialog dialog)
+        {
+            // ༼ つ ◕_◕ ༽つ IMPEACH STAThread ༼ つ ◕_◕ ༽つ
+            var wait = new AutoResetEvent(false);
+            bool success = false;
+            var thread = new Thread(() => {
+                success = DialogResult.OK == dialog.ShowDialog();
+                wait.Set();
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            wait.WaitOne();
+            return success;
+        }
+
+        private void FramesButton_Click(object sender, EventArgs e)
+        {
+            FramesMode = !FramesMode;
+            SetActiveResource(GraphicChunk, ActiveIff);
+        }
+    }
+}

--- a/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/SPRResourceControl.resx
+++ b/TSOClient/FSO.IDE/ResourceBrowser/ResourceEditors/SPRResourceControl.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/TSOClient/FSO.IDE/ResourceBrowser/SelectorDialogs/ExternalIffSelectorDialog.Designer.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/SelectorDialogs/ExternalIffSelectorDialog.Designer.cs
@@ -1,0 +1,180 @@
+﻿namespace FSO.IDE.ResourceBrowser.SelectorDialogs
+{
+    partial class ExternalIffSelectorDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.IffLinkLabel = new System.Windows.Forms.LinkLabel();
+            this.SPFLinkLabel = new System.Windows.Forms.LinkLabel();
+            this.IffEditorButton = new System.Windows.Forms.Button();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.OBJDEditorButton = new System.Windows.Forms.Button();
+            this.ExitButton = new System.Windows.Forms.Button();
+            this.groupBox1.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox1.Controls.Add(this.SPFLinkLabel);
+            this.groupBox1.Controls.Add(this.IffLinkLabel);
+            this.groupBox1.Controls.Add(this.label2);
+            this.groupBox1.Controls.Add(this.label1);
+            this.groupBox1.Location = new System.Drawing.Point(13, 13);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(316, 103);
+            this.groupBox1.TabIndex = 0;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "File";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(7, 20);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(43, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Iff File";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(7, 59);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(50, 13);
+            this.label2.TabIndex = 1;
+            this.label2.Text = "Spf File";
+            // 
+            // IffLinkLabel
+            // 
+            this.IffLinkLabel.AutoSize = true;
+            this.IffLinkLabel.Location = new System.Drawing.Point(10, 39);
+            this.IffLinkLabel.Name = "IffLinkLabel";
+            this.IffLinkLabel.Size = new System.Drawing.Size(69, 13);
+            this.IffLinkLabel.TabIndex = 2;
+            this.IffLinkLabel.TabStop = true;
+            this.IffLinkLabel.Text = "Not Selected";
+            this.IffLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.IffLinkLabel_LinkClicked);
+            // 
+            // SPFLinkLabel
+            // 
+            this.SPFLinkLabel.AutoSize = true;
+            this.SPFLinkLabel.Location = new System.Drawing.Point(10, 76);
+            this.SPFLinkLabel.Name = "SPFLinkLabel";
+            this.SPFLinkLabel.Size = new System.Drawing.Size(69, 13);
+            this.SPFLinkLabel.TabIndex = 3;
+            this.SPFLinkLabel.TabStop = true;
+            this.SPFLinkLabel.Text = "Not Selected";
+            this.SPFLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.SPFLinkLabel_LinkClicked);
+            // 
+            // IffEditorButton
+            // 
+            this.IffEditorButton.Location = new System.Drawing.Point(3, 3);
+            this.IffEditorButton.Name = "IffEditorButton";
+            this.IffEditorButton.Size = new System.Drawing.Size(99, 46);
+            this.IffEditorButton.TabIndex = 5;
+            this.IffEditorButton.Text = "Open IFF Editor";
+            this.IffEditorButton.UseVisualStyleBackColor = true;
+            this.IffEditorButton.Click += new System.EventHandler(this.IffEditorButton_Click);
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+            this.tableLayoutPanel1.Controls.Add(this.ExitButton, 2, 0);
+            this.tableLayoutPanel1.Controls.Add(this.OBJDEditorButton, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.IffEditorButton, 0, 0);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(14, 121);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 1;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(315, 52);
+            this.tableLayoutPanel1.TabIndex = 6;
+            // 
+            // OBJDEditorButton
+            // 
+            this.OBJDEditorButton.Location = new System.Drawing.Point(108, 3);
+            this.OBJDEditorButton.Name = "OBJDEditorButton";
+            this.OBJDEditorButton.Size = new System.Drawing.Size(99, 46);
+            this.OBJDEditorButton.TabIndex = 6;
+            this.OBJDEditorButton.Text = "Open OBJD Editor";
+            this.OBJDEditorButton.UseVisualStyleBackColor = true;
+            this.OBJDEditorButton.Click += new System.EventHandler(this.OBJDEditorButton_Click);
+            // 
+            // ExitButton
+            // 
+            this.ExitButton.Location = new System.Drawing.Point(213, 3);
+            this.ExitButton.Name = "ExitButton";
+            this.ExitButton.Size = new System.Drawing.Size(99, 46);
+            this.ExitButton.TabIndex = 7;
+            this.ExitButton.Text = "Cancel";
+            this.ExitButton.UseVisualStyleBackColor = true;
+            this.ExitButton.Click += new System.EventHandler(this.ExitButton_Click);
+            // 
+            // ExternalIffSelectorDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(341, 185);
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Controls.Add(this.groupBox1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Name = "ExternalIffSelectorDialog";
+            this.ShowIcon = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Open External Iff";
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.LinkLabel SPFLinkLabel;
+        private System.Windows.Forms.LinkLabel IffLinkLabel;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Button IffEditorButton;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Button ExitButton;
+        private System.Windows.Forms.Button OBJDEditorButton;
+    }
+}

--- a/TSOClient/FSO.IDE/ResourceBrowser/SelectorDialogs/ExternalIffSelectorDialog.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/SelectorDialogs/ExternalIffSelectorDialog.cs
@@ -1,0 +1,139 @@
+﻿using FSO.Files.Formats.IFF;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;
+
+namespace FSO.IDE.ResourceBrowser.SelectorDialogs
+{
+    public partial class ExternalIffSelectorDialog : Form
+    {
+        public IffFile Iff { get; private set; }
+        public IffFile Spf { get; private set; }
+        /// <summary>
+        /// 1 = Open OBJD Editor 2 = Open Iff Editor
+        /// </summary>
+        public int Selection { get; private set; } = -1;
+
+        public ExternalIffSelectorDialog()
+        {
+            InitializeComponent();
+        }
+
+        internal static IffFile OpenExternalIff(out string FilePath, bool SPFFile = false)
+        {
+            FilePath = null;
+            bool SaveFile(FileDialog Dialog)
+            {
+                // ༼ つ ◕_◕ ༽つ IMPEACH STAThread ༼ つ ◕_◕ ༽つ
+                var wait = new AutoResetEvent(false);
+                DialogResult result = DialogResult.None;
+                var thread = new Thread(() => {
+                    result = Dialog.ShowDialog();
+                    wait.Set();
+                });
+                thread.SetApartmentState(ApartmentState.STA);
+                thread.Start();
+                wait.WaitOne();
+                return result == DialogResult.OK;
+            }
+
+            var dialog = new OpenFileDialog();
+            string noun = SPFFile ? "SPF" : "IFF";
+            dialog.Title = $"Select an {noun} file. (*.{noun})";
+            if (!SaveFile(dialog)) return null;
+            try
+            {
+                var iff = new IffFile(dialog.FileName);
+                iff.TSBO = true;
+                FilePath = dialog.FileName;
+#if false
+                //SHOW BMPS
+                var bmps = iff.List<BMP>();
+                if (bmps?.Any() ?? false)
+                {
+                    Invoke(new MethodInvoker(delegate
+                    {
+                        Form imgForm = new Form();
+                        var picBox = new PictureBox();
+                        imgForm.Controls.Add(picBox);
+                        foreach (var image in bmps)
+                        {
+                            using (var buffer = new MemoryStream(image.data.ToArray()))
+                            {
+                                Image mngImg = Image.FromStream(buffer);
+                                picBox.Image = mngImg;
+                            }
+                            imgForm.ShowDialog();
+                        }
+                    }));
+                }          
+#endif
+                return iff;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+            return null;
+        }
+
+        private void IffLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Iff = OpenExternalIff(out var fileName);
+            IffLinkLabel.Text = fileName;
+            string spfFileName = fileName.Remove(fileName.Length - 3) + "spf";
+            if (!File.Exists(spfFileName)) return;
+            if (MessageBox.Show($"Select {Path.GetFileName(spfFileName)}?", "Autoselect", MessageBoxButtons.YesNo) != DialogResult.Yes) return;
+            SelectSpfFile(ref spfFileName);
+        }
+
+        void SelectSpfFile(ref string SpfFileName)
+        {
+            IffFile spf = default;
+            if (string.IsNullOrWhiteSpace(SpfFileName) || !File.Exists(SpfFileName))            
+                spf = OpenExternalIff(out SpfFileName, true);
+            else
+            {
+                spf = new IffFile(SpfFileName);
+                spf.TSBO = true;
+            }
+            SPFLinkLabel.Text = SpfFileName;
+            Spf = spf;
+        }
+
+        private void SPFLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            string filename = "";
+            SelectSpfFile(ref filename);
+        }
+
+        private void IffEditorButton_Click(object sender, EventArgs e)
+        {
+            if (Iff == null && Spf == null) return;
+            Selection = 2;
+            Close();
+        }
+
+        private void OBJDEditorButton_Click(object sender, EventArgs e)
+        {
+            if (Iff == null && Spf == null) return;
+            Selection = 1;
+            Close();
+        }
+
+        private void ExitButton_Click(object sender, EventArgs e)
+        {
+            Selection = -1;
+            Close();
+        }
+    }
+}

--- a/TSOClient/FSO.IDE/ResourceBrowser/SelectorDialogs/ExternalIffSelectorDialog.cs
+++ b/TSOClient/FSO.IDE/ResourceBrowser/SelectorDialogs/ExternalIffSelectorDialog.cs
@@ -1,18 +1,10 @@
 ﻿using FSO.Files.Formats.IFF;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;
 
-namespace FSO.IDE.ResourceBrowser.SelectorDialogs
+namespace FSO.IDE.ResourceBrowser
 {
     public partial class ExternalIffSelectorDialog : Form
     {
@@ -55,28 +47,6 @@ namespace FSO.IDE.ResourceBrowser.SelectorDialogs
                 var iff = new IffFile(dialog.FileName);
                 iff.TSBO = true;
                 FilePath = dialog.FileName;
-#if false
-                //SHOW BMPS
-                var bmps = iff.List<BMP>();
-                if (bmps?.Any() ?? false)
-                {
-                    Invoke(new MethodInvoker(delegate
-                    {
-                        Form imgForm = new Form();
-                        var picBox = new PictureBox();
-                        imgForm.Controls.Add(picBox);
-                        foreach (var image in bmps)
-                        {
-                            using (var buffer = new MemoryStream(image.data.ToArray()))
-                            {
-                                Image mngImg = Image.FromStream(buffer);
-                                picBox.Image = mngImg;
-                            }
-                            imgForm.ShowDialog();
-                        }
-                    }));
-                }          
-#endif
                 return iff;
             }
             catch (Exception ex)
@@ -89,6 +59,7 @@ namespace FSO.IDE.ResourceBrowser.SelectorDialogs
         private void IffLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Iff = OpenExternalIff(out var fileName);
+            if (Iff == null) return; // User cancelled
             IffLinkLabel.Text = fileName;
             string spfFileName = fileName.Remove(fileName.Length - 3) + "spf";
             if (!File.Exists(spfFileName)) return;
@@ -103,9 +74,14 @@ namespace FSO.IDE.ResourceBrowser.SelectorDialogs
                 spf = OpenExternalIff(out SpfFileName, true);
             else
             {
-                spf = new IffFile(SpfFileName);
-                spf.TSBO = true;
+                try
+                {
+                    spf = new IffFile(SpfFileName);
+                    spf.TSBO = true;
+                }
+                catch (Exception e) { MessageBox.Show(e.Message); }
             }
+            if (spf == null) return;
             SPFLinkLabel.Text = SpfFileName;
             Spf = spf;
         }

--- a/TSOClient/FSO.IDE/ResourceBrowser/SelectorDialogs/ExternalIffSelectorDialog.resx
+++ b/TSOClient/FSO.IDE/ResourceBrowser/SelectorDialogs/ExternalIffSelectorDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/TSOClient/tso.files/Formats/IFF/Chunks/PALT.cs
+++ b/TSOClient/tso.files/Formats/IFF/Chunks/PALT.cs
@@ -1,5 +1,16 @@
-﻿using System.IO;
+﻿/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/. 
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
 using FSO.Files.Utils;
+using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework;
 
 namespace FSO.Files.Formats.IFF.Chunks
@@ -21,9 +32,39 @@ namespace FSO.Files.Formats.IFF.Chunks
                 Colors[i] = color;
             }
         }
+        /// <summary>
+        /// Makes a new <see cref="PALT"/> which is populated with <paramref name="Colors"/> 
+        /// in order, then filled with <paramref name="fillColor"/> to the end of the palette.
+        /// </summary>
+        /// <param name="fillColor"></param>
+        /// <param name="Colors"></param>
+        public PALT(Color fillColor, params Color[] Colors)
+        {
+            Colors = new Color[256];
+            for (int i = 0; i < 256; i++)
+            {
+                var color = i < Colors.Length ? Colors[i] : fillColor;
+                Colors[i] = color;
+            }
+        }
 
         public Color[] Colors;
         public int References = 0;
+
+        public static PALT Greyscale
+        {
+            get
+            {
+                PALT newPalt = new PALT();
+                newPalt.Colors = new Color[256];
+                ref var colors = ref newPalt.Colors;
+                for (int i = 0; i < 256; i++)
+                {
+                    colors[i] = new Color(i, i, i, 255);
+                }
+                return newPalt;
+            }
+        }
 
         /// <summary>
         /// Reads a PALT chunk from a stream.

--- a/TSOClient/tso.files/Formats/IFF/Chunks/PALT.cs
+++ b/TSOClient/tso.files/Formats/IFF/Chunks/PALT.cs
@@ -38,12 +38,12 @@ namespace FSO.Files.Formats.IFF.Chunks
         /// </summary>
         /// <param name="fillColor"></param>
         /// <param name="Colors"></param>
-        public PALT(Color fillColor, params Color[] Colors)
+        public PALT(Color fillColor, params Color[] colors)
         {
             Colors = new Color[256];
             for (int i = 0; i < 256; i++)
             {
-                var color = i < Colors.Length ? Colors[i] : fillColor;
+                var color = i < colors.Length ? colors[i] : fillColor;
                 Colors[i] = color;
             }
         }

--- a/TSOClient/tso.files/Formats/IFF/Chunks/STR.cs
+++ b/TSOClient/tso.files/Formats/IFF/Chunks/STR.cs
@@ -1,6 +1,13 @@
-﻿using System;
+﻿/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/. 
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.IO;
 using FSO.Files.Utils;
 
@@ -218,7 +225,23 @@ namespace FSO.Files.Formats.IFF.Chunks
                     for (int i = 0; i < 20; i++) LanguageSets[i] = new STRLanguageSet { Strings = new STRItem[0] };
                     return;
                 }
+                //Sims Steering Commitee STR# format *Bisquick
+                if (ChunkParent.FileVersion == IffFile.IffFileVersion.v1)
+                {
+                    var numStrings = 1; // only ever one string in these to my knowledge
+                    for (int i = 0; i < 20; i++) LanguageSets[i] = new STRLanguageSet { Strings = new STRItem[0] };
+                    LanguageSets[0].Strings = new STRItem[numStrings];
 
+                    _ = io.ReadUInt32(); // unknown
+                    var unknownCode = io.ReadUInt16();
+                    var unknownCode2 = io.ReadUInt16();                    
+                    //PASCAL
+                    LanguageSets[0].Strings[0] = new STRItem
+                    {
+                        Value = io.ReadPascalString()
+                    };
+                    return;
+                }
                 if (formatCode == 0)
                 {
                     var numStrings = io.ReadUInt16();

--- a/TSOClient/tso.files/Formats/IFF/IffFile.cs
+++ b/TSOClient/tso.files/Formats/IFF/IffFile.cs
@@ -187,10 +187,9 @@ namespace FSO.Files.Formats.IFF
                 if (identifier.StartsWith("IFF FILE 1.0"))
                 {
                     FileVersion = IffFileVersion.v1;
-                    _ = io.ReadCString(4);
-                    goto iff1;
+                    _ = io.ReadCString(4);                    
                 }
-                if (identifier != "IFF FILE 2.5:TYPE FOLLOWED BY SIZE JAMIE DOORNBOS & MAXIS 1")
+                else if (identifier != "IFF FILE 2.5:TYPE FOLLOWED BY SIZE JAMIE DOORNBOS & MAXIS 1")
                 {
                     FileVersion = IffFileVersion.Unrecognized;
                     if (identifier != "IFF FILE 2.0:TYPE FOLLOWED BY SIZE JAMIE DOORNBOS & MAXIS 1") //house11.iff, seems to read fine
@@ -199,7 +198,7 @@ namespace FSO.Files.Formats.IFF
                 }
 
                 var rsmpOffset = io.ReadUInt32();
-            iff1:
+
                 while (io.HasMore)
                 {
                     var newChunk = AddChunk(stream, io, true);
@@ -249,7 +248,7 @@ namespace FSO.Files.Formats.IFF
                         ChunkSize = io.ReadUInt32();
                         ID = io.ReadUInt16();
                         _ = io.ReadUInt16();
-                        Flags = (ushort)io.ReadUInt32(); // truncate >.<
+                        Flags = (ushort)io.ReadUInt32();
                         int number = 1;
                         if (CHUNK_TYPES.TryGetValue(Type, out var type))
                         {

--- a/TSOClient/tso.files/Formats/IFF/IffFile.cs
+++ b/TSOClient/tso.files/Formats/IFF/IffFile.cs
@@ -1,9 +1,17 @@
-﻿using System;
+﻿/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/. 
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.IO;
 using FSO.Files.Formats.IFF.Chunks;
 using FSO.Files.Utils;
+using System.Reflection;
 using FSO.Common.Utils;
 
 namespace FSO.Files.Formats.IFF
@@ -14,6 +22,26 @@ namespace FSO.Files.Formats.IFF
     /// </summary>
     public class IffFile : IFileInfoUtilizer, ITimedCachable
     {
+        public enum IffFileVersion
+        {
+            Unrecognized,
+            /// <summary>
+            /// IFF FILE v2.0
+            /// </summary>
+            v2,
+            /// <summary>
+            /// IFF FILE v2.5
+            /// </summary>
+            v25,
+            /// <summary>
+            /// IFF FILE v1.0
+            /// </summary>
+            v1
+        }
+        /// <summary>
+        /// The version of IFF File being read
+        /// </summary>
+        public IffFileVersion FileVersion;
         /// <summary>
         /// Set to true to force the game to retain a copy of all chunk data at time of loading (used to generate piffs)
         /// Should really only be set when the user wants to use the IDE, as it uses a lot more memory.
@@ -152,18 +180,26 @@ namespace FSO.Files.Formats.IFF
         /// <param name="stream">The stream to read from.</param>
         public void Read(Stream stream)
         {
-
+            FileVersion = IffFileVersion.v25;
             using (var io = IoBuffer.FromStream(stream, ByteOrder.BIG_ENDIAN))
             {
                 var identifier = io.ReadCString(60, false).Replace("\0", "");
+                if (identifier.StartsWith("IFF FILE 1.0"))
+                {
+                    FileVersion = IffFileVersion.v1;
+                    _ = io.ReadCString(4);
+                    goto iff1;
+                }
                 if (identifier != "IFF FILE 2.5:TYPE FOLLOWED BY SIZE JAMIE DOORNBOS & MAXIS 1")
                 {
+                    FileVersion = IffFileVersion.Unrecognized;
                     if (identifier != "IFF FILE 2.0:TYPE FOLLOWED BY SIZE JAMIE DOORNBOS & MAXIS 1") //house11.iff, seems to read fine
                         throw new Exception("Invalid iff file!");
+                    FileVersion = IffFileVersion.v2;
                 }
 
                 var rsmpOffset = io.ReadUInt32();
-                
+            iff1:
                 while (io.HasMore)
                 {
                     var newChunk = AddChunk(stream, io, true);
@@ -188,14 +224,49 @@ namespace FSO.Files.Formats.IFF
             }
         }
 
+        void ReadHeader(in IoBuffer io, out string Type, out UInt32 ChunkSize, out ushort ID, out ushort Flags, out string Label, out uint DataSize)
+        {
+            switch (FileVersion)
+            {
+                case IffFileVersion.Unrecognized:
+                    throw new Exception("Invalid Iff file header!");
+                default:
+                case IffFileVersion.v2:
+                case IffFileVersion.v25:
+                    {
+                        Type = io.ReadCString(4);
+                        ChunkSize = io.ReadUInt32();
+                        ID = io.ReadUInt16();
+                        Flags = io.ReadUInt16();
+                        Label = io.ReadCString(64).TrimEnd('\0');
+                        DataSize = ChunkSize - 76;
+                    }
+                    return;
+                case IffFileVersion.v1:
+                    {
+                        //TYPE (char[4]) SIZE (uint32) ID (uint16) UNK (uint15) FLAGS (uint32) [16 bytes] 
+                        Type = io.ReadCString(4);
+                        ChunkSize = io.ReadUInt32();
+                        ID = io.ReadUInt16();
+                        _ = io.ReadUInt16();
+                        Flags = (ushort)io.ReadUInt32(); // truncate >.<
+                        int number = 1;
+                        if (CHUNK_TYPES.TryGetValue(Type, out var type))
+                        {
+                            if (ByChunkType.TryGetValue(type, out var list))
+                                number = (ushort)(list.Count + 1);
+                        }
+                        Label = $"{Type}{number}";
+                        DataSize = ChunkSize - 16;
+                    }
+                    return;
+            }
+        }
+
         public IffChunk AddChunk(Stream stream, IoBuffer io, bool add)
         {
-            var chunkType = io.ReadCString(4);
-            var chunkSize = io.ReadUInt32();
-            var chunkID = io.ReadUInt16();
-            var chunkFlags = io.ReadUInt16();
-            var chunkLabel = io.ReadCString(64).TrimEnd('\0');
-            var chunkDataSize = chunkSize - 76;
+            ReadHeader(in io, out string chunkType, out uint chunkSize, 
+                out ushort chunkID, out ushort chunkFlags, out string chunkLabel, out uint chunkDataSize);
 
             /** Do we understand this chunk type? **/
             if (!CHUNK_TYPES.ContainsKey(chunkType))


### PR DESCRIPTION
**Brief**
Add support for viewing IFF v1.0 in Volcanic. Supported chunk types are: SPR#, BHAV (wip), STR.

Sprites
![image](https://github.com/riperiperi/FreeSO/assets/16988651/b4a38fe0-a31e-4e24-8779-c3b871e40b6a)
Z-Buffers
![image](https://github.com/riperiperi/FreeSO/assets/16988651/16c18734-f05f-449f-a18b-c2704a8a6f47)

Sprites that are not inherently objects can also be viewed by using the 'Frames/Rotations' button on SPRResourceControl to view them as frames and not interpreted as an object
![image](https://github.com/riperiperi/FreeSO/assets/16988651/4d34d7ff-d007-4fa0-aa9e-ad01127cdbf1)

Exported Sprites
![image](https://github.com/riperiperi/FreeSO/assets/16988651/dcf7d91b-e5f0-43f0-a8ac-f472ed014dc5)

BHAV (wip)
![image](https://github.com/riperiperi/FreeSO/assets/16988651/9f42bcba-3cc0-4ad2-b775-ce11d4d07a7c)

**Video**
[Here is a recorded video](https://1drv.ms/v/s!AuOXXqHhGp4kgr4bCOkq5_p9flXlrQ?e=C3XxQQ) demonstrating how the submission works (OneDrive)

**Changes Summary**
 * Add support for IFF 1.0 Header
 * Add SPFResControl for viewing SPF# chunks
 * Modified STR chunk reader to use parent IFF file version to read strings from Steering Commitee IFF files
 * Add Grayscale PALT by default instead of all black
   * Add contructor overload for PALT to allow for manually-built color palettes (unused as of now)
 * Modified Toolstrip Items for loading External Iff in MainWindow.cs to support Iff & Spf and added a special dialog for loading both at once into a GameObject.
 * Modified IFFResComponent to support SPR# resources using the SPRResControl
 * Added methods in SpriteEncoderUtils to support SPR# resources

All of these changes isolate themselves from any existing functionality and use the existing functionality as a baseline to implement the new features to remain consistent.