### PR TITLE
Correct capitalization for the Protobuild command in documentation

### DIFF
--- a/Documentation/Building FreeSO.md
+++ b/Documentation/Building FreeSO.md
@@ -28,7 +28,7 @@ First, make sure you have cloned FreeSO _with_ submodules. If the folder `./Othe
 
 ![Protobuild running in PowerShell](./media/protobuild.png)
 
-Next, you want to run `./protobuild.exe --generate` from the directory `./Other/libs/FSOMonoGame/`. This will generate the Monogame projects that FreeSO uses.
+Next, you want to run `.\Protobuild.exe --generate` from the directory `./Other/libs/FSOMonoGame/`. This will generate the Monogame projects that FreeSO uses.
 
 You can now open the FreeSO solution and build it in Visual Studio. Open `./TSOClient/FreeSO.sln`, and you should be ready to go.
 


### PR DESCRIPTION
This PR updates the capitalization of the Protobuild.exe command in the documentation, making it easier to copy and paste directly instead of typing it myself from the screenshot :)