### PR TITLE
UIListBox keyboard navigation

### DIFF
--- a/TSOClient/FSO.UI/Controls/UIListBox.cs
+++ b/TSOClient/FSO.UI/Controls/UIListBox.cs
@@ -7,6 +7,7 @@ using Microsoft.Xna.Framework.Graphics;
 using FSO.Common.Rendering.Framework.IO;
 using FSO.Common.Rendering.Framework.Model;
 using FSO.Common.Utils;
+using Microsoft.Xna.Framework.Input;
 
 namespace FSO.Client.UI.Controls
 {
@@ -276,6 +277,15 @@ namespace FSO.Client.UI.Controls
 
             if (m_MouseOver)
             {
+                if (state.NewKeys.Contains(Keys.Up) && Items.Count > 0) 
+                    InternalSelect((m_SelectedRow - 1 + Items.Count) % Items.Count);
+
+                if (state.NewKeys.Contains(Keys.Down) && Items.Count > 0) 
+                    InternalSelect((m_SelectedRow + 1) % Items.Count);
+
+                if (SelectedItem != null && state.NewKeys.Contains(Keys.Enter)) 
+                    OnDoubleClick?.Invoke(this);
+                
                 var overRow = GetRowUnderMouse(state);
                 m_HoverRow = overRow;
             }
@@ -347,6 +357,15 @@ namespace FSO.Client.UI.Controls
         {
             Invalidate();
             m_SelectedRow = index;
+            
+            // Ensure selection is visible
+            if (index < ScrollOffset && index != -1)
+                ScrollOffset = index;
+            else if (index >= ScrollOffset + NumVisibleRows)
+                ScrollOffset = index - NumVisibleRows + 1;
+            
+            if (m_Slider != null)
+                m_Slider.Value = ScrollOffset;
 
             if (OnChange != null)
             {

--- a/TSOClient/FSO.UI/Controls/UIListBox.cs
+++ b/TSOClient/FSO.UI/Controls/UIListBox.cs
@@ -280,7 +280,7 @@ namespace FSO.Client.UI.Controls
             if (IsFocused)
             {
                 if (state.NewKeys.Contains(Keys.Up) && Items.Count > 0) 
-                    InternalSelect((m_SelectedRow - 1 + Items.Count) % Items.Count);
+                    InternalSelect((m_SelectedRow < 0 ? Items.Count - 1 : (m_SelectedRow - 1 + Items.Count) % Items.Count));
 
                 if (state.NewKeys.Contains(Keys.Down) && Items.Count > 0) 
                     InternalSelect((m_SelectedRow + 1) % Items.Count);

--- a/TSOClient/FSO.UI/Controls/UIListBox.cs
+++ b/TSOClient/FSO.UI/Controls/UIListBox.cs
@@ -28,11 +28,7 @@ namespace FSO.Client.UI.Controls
         {
             MouseHandler = this.ListenForMouse(new Rectangle(0, 0, 10, 10), OnMouseEvent);
             RowHeight = 16;
-            GameFacade.Screens.inputManager.SetFocus(this);
         }
-
-
-
 
         #region Fields
 

--- a/TSOClient/FSO.UI/Controls/UIListBox.cs
+++ b/TSOClient/FSO.UI/Controls/UIListBox.cs
@@ -11,7 +11,7 @@ using Microsoft.Xna.Framework.Input;
 
 namespace FSO.Client.UI.Controls
 {
-    public class UIListBox : UIElement
+    public class UIListBox : UIElement, IFocusableUI
     {
         private UIMouseEventRef MouseHandler;
         public event ChangeDelegate OnChange;
@@ -22,11 +22,13 @@ namespace FSO.Client.UI.Controls
 
         public bool AllowDisabledSelection = false;
         public bool Mask = false;
+        private bool IsFocused;
 
         public UIListBox()
         {
             MouseHandler = this.ListenForMouse(new Rectangle(0, 0, 10, 10), OnMouseEvent);
             RowHeight = 16;
+            GameFacade.Screens.inputManager.SetFocus(this);
         }
 
 
@@ -275,7 +277,7 @@ namespace FSO.Client.UI.Controls
                 }
             }
 
-            if (m_MouseOver)
+            if (IsFocused)
             {
                 if (state.NewKeys.Contains(Keys.Up) && Items.Count > 0) 
                     InternalSelect((m_SelectedRow - 1 + Items.Count) % Items.Count);
@@ -285,7 +287,10 @@ namespace FSO.Client.UI.Controls
 
                 if (SelectedItem != null && state.NewKeys.Contains(Keys.Enter)) 
                     OnDoubleClick?.Invoke(this);
-                
+            }
+
+            if (m_MouseOver)
+            {
                 var overRow = GetRowUnderMouse(state);
                 m_HoverRow = overRow;
             }
@@ -323,6 +328,7 @@ namespace FSO.Client.UI.Controls
                         /** Cant deselect once selected **/
                         InternalSelect(row);
                     }
+                    GameFacade.Screens.inputManager.SetFocus(this);
                     break;
             }
         }
@@ -655,6 +661,10 @@ namespace FSO.Client.UI.Controls
             base.Removed();
         }
 
+        public void OnFocusChanged(FocusEvent newFocus)
+        {
+            IsFocused = newFocus == FocusEvent.FocusIn;
+        }
     }
 
     public class UIListBoxColumn

--- a/TSOClient/tso.client/UI/Panels/UISandboxSelector.cs
+++ b/TSOClient/tso.client/UI/Panels/UISandboxSelector.cs
@@ -106,9 +106,9 @@ namespace FSO.Client.UI.Panels
             casButton.Caption = "CAS";
             casButton.OnButtonClick += (btn) =>
             {
-                if (UIScreen.Current is SandboxGameScreen)
+                if (UIScreen.Current is SandboxGameScreen screen)
                 {
-                    ((SandboxGameScreen)UIScreen.Current).CleanupLastWorld();
+                    screen.CleanupLastWorld();
                 }
                 FSOFacade.Controller.ShowPersonCreation(null);
             };
@@ -118,6 +118,8 @@ namespace FSO.Client.UI.Panels
             Add(casButton);
 
             SetSize(300, 500);
+            
+            GameFacade.Screens.inputManager.SetFocus(BookmarkListBox);
         }
 
         public void LotSwitch(string location, bool external)

--- a/TSOClient/tso.client/UI/Screens/SandboxGameScreen.cs
+++ b/TSOClient/tso.client/UI/Screens/SandboxGameScreen.cs
@@ -21,6 +21,7 @@ using FSO.SimAntics.NetPlay.Drivers;
 using FSO.SimAntics.NetPlay.Model;
 using FSO.SimAntics.NetPlay.Model.Commands;
 using FSO.SimAntics.Utils;
+using FSO.LotView;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using System;
@@ -588,6 +589,11 @@ namespace FSO.Client.UI.Screens
                 AssetStreaming.DigestStreamUpdate();
             }
             AssetStreaming.EndStreaming();
+            
+            if (LotView.WorldConfig.Current.SurroundingLots > 0)
+            {
+                SimAntics.Utils.VMLotTerrainRestoreTools.RestoreSurroundings(vm, vm.HollowAdj);
+            }
         }
 
         public void BlueprintReset(string path)

--- a/TSOClient/tso.client/UI/Screens/SandboxGameScreen.cs
+++ b/TSOClient/tso.client/UI/Screens/SandboxGameScreen.cs
@@ -507,11 +507,6 @@ namespace FSO.Client.UI.Screens
             LotControl = new UILotControl(vm, World);
             this.AddAt(0, LotControl);
 
-            var time = DateTime.UtcNow;
-            var tsoTime = TSOTime.FromUTC(time);
-
-            vm.Context.Clock.Hours = tsoTime.Item1;
-            vm.Context.Clock.Minutes = tsoTime.Item2;
             if (m_ZoomLevel > 3)
             {
                 World.Visible = false;
@@ -581,6 +576,17 @@ namespace FSO.Client.UI.Screens
             }
             vm.MyUID = myState.PersistID;
             ZoomLevel = 1;
+            
+            var time = DateTime.UtcNow;
+            var tsoTime = TSOTime.FromUTC(time);
+
+            vm.Context.Clock.Hours = tsoTime.Item1;
+            vm.Context.Clock.Minutes = tsoTime.Item2;
+            
+            if (LotView.WorldConfig.Current.SurroundingLots > 0)
+            {
+                SimAntics.Utils.VMLotTerrainRestoreTools.RestoreSurroundings(vm, vm.HollowAdj);
+            }
 
             AssetStreaming.BeginStreaming(AssetStreamingMode.Lot);
             while (!World.Preload(GameFacade.GraphicsDevice))
@@ -589,11 +595,6 @@ namespace FSO.Client.UI.Screens
                 AssetStreaming.DigestStreamUpdate();
             }
             AssetStreaming.EndStreaming();
-            
-            if (LotView.WorldConfig.Current.SurroundingLots > 0)
-            {
-                SimAntics.Utils.VMLotTerrainRestoreTools.RestoreSurroundings(vm, vm.HollowAdj);
-            }
         }
 
         public void BlueprintReset(string path)

--- a/TSOClient/tso.simantics/NetPlay/Model/Commands/VMNetChatCmd.cs
+++ b/TSOClient/tso.simantics/NetPlay/Model/Commands/VMNetChatCmd.cs
@@ -141,6 +141,19 @@ namespace FSO.SimAntics.NetPlay.Model.Commands
                         vm.Context.Clock.Minutes = int.Parse(timesplit[1]);
                         vm.Context.Clock.MinuteFractions = 0;
                         break;
+                    case "tickrate":
+                        /* TS1 has 30 ticks per minute (1 minute per 1 irl second)
+                         * TSO has 150 ticks per minute (1 minute per 5 irl second)*/
+                        if (int.TryParse(args, out var tick) && tick >= 1) vm.Context.Clock.TicksPerMinute = tick;
+                        else tick = vm.Context.Clock.TicksPerMinute = 30 * 5;
+                        vm.SignalChatEvent(new VMChatEvent(null, VMChatEventType.Generic, $"Set tickrate to {tick} ticks per minute."));
+                        break;
+                    case "speed":
+                        /* By default, 0 = paused, normal = 1, medium = 3, fast = 10 */
+                        if (int.TryParse(args, out var speed) && speed is >= 0 and <= 999) vm.SpeedMultiplier = speed;
+                        else vm.SpeedMultiplier = speed = 1;
+                        vm.SignalChatEvent(new VMChatEvent(null, VMChatEventType.Generic, $"Set speed multiplier to {speed}."));
+                        break;
                     case "tuning":
                         var tuningsplit = args.Split(' ');
                         if (tuningsplit.Length < 4) return true;


### PR DESCRIPTION
This pull request enhances the `UIListBox` control by adding keyboard navigation.

* Added support for the `Up` and `Down` arrow keys to move the selection up and down.
* Added support for the `Enter` key to trigger the double-click event when an item is selected.
* Added wrap-around logic when navigating past the first or last item.
* Updates the scrollbar loaction while moving with the keyboard.
* Improves the **Sandbox Mode list** for smoother navigation <sub style="color:gray;">(also applies to the Archive character selection, i think).</sub>

> Initially, it found it unclear to double-click to start a lot, this makes that interaction more user-friendly.

let me know if this is something you want or not