### PR TITLE
Adding in support for non-windows OSes for Simitone

### DIFF
--- a/TSOClient/FSO.Server.Api.Core/FSO.Server.Api.Core.csproj
+++ b/TSOClient/FSO.Server.Api.Core/FSO.Server.Api.Core.csproj
@@ -1,10 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <IsAotCompatible>True</IsAotCompatible>
+    <!-- disable apphost for self-contained builds to avoid conflicts when referenced as dependency -->
+    <UseAppHost Condition="'$(SelfContained)' != 'true'">false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TSOClient/FSO.Server.Updater/FSO.Server.Watchdog.csproj
+++ b/TSOClient/FSO.Server.Updater/FSO.Server.Watchdog.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -8,6 +8,8 @@
     <RootNamespace>FSO.Server.Watchdog</RootNamespace>
     <AssemblyName>watchdog</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <!-- disable apphost for self-contained builds to avoid conflicts when referenced as dependency -->
+    <UseAppHost Condition="'$(SelfContained)' != 'true'">false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TSOClient/tso.common/Utils/PathCaseTools.cs
+++ b/TSOClient/tso.common/Utils/PathCaseTools.cs
@@ -19,27 +19,22 @@ namespace FSO.Common.Utils
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
                 return File.Exists(file) ? file : null;
 
-            // Normalize path separators for Unix
             file = file.Replace('\\', '/');
 
-            // Split path into components
             string[] parts;
             string resolved;
 
             if (file.StartsWith("/"))
             {
-                // Absolute path
                 parts = file.Substring(1).Split('/');
                 resolved = "/";
             }
             else
             {
-                // Relative path
                 parts = file.Split('/');
                 resolved = "";
             }
 
-            // Resolve each path component case-insensitively
             foreach (var part in parts)
             {
                 if (string.IsNullOrEmpty(part))

--- a/TSOClient/tso.common/Utils/PathCaseTools.cs
+++ b/TSOClient/tso.common/Utils/PathCaseTools.cs
@@ -16,7 +16,7 @@ namespace FSO.Common.Utils
                 return null;
 
             // On Windows, file system is case-insensitive, just check existence
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (OperatingSystem.IsWindows())
                 return File.Exists(file) ? file : null;
 
             file = file.Replace('\\', '/');

--- a/TSOClient/tso.common/Utils/PathCaseTools.cs
+++ b/TSOClient/tso.common/Utils/PathCaseTools.cs
@@ -1,14 +1,73 @@
-﻿using System.IO;
+using System;
+using System.IO;
 using System.Linq;
 
 namespace FSO.Common.Utils
 {
     public static class PathCaseTools
     {
+        /// <summary>
+        /// Resolves a file path case-insensitively on Linux/macOS.
+        /// On Windows, simply checks if the file exists.
+        /// </summary>
         public static string Insensitive(string file)
         {
-            var dir = Directory.GetFiles(Path.GetDirectoryName(file));
-            return dir.FirstOrDefault(x => x.ToLowerInvariant().Replace('\\', '/') == file.ToLowerInvariant().Replace('\\', '/'));
+            if (string.IsNullOrEmpty(file))
+                return null;
+
+            // On Windows, file system is case-insensitive, just check existence
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                return File.Exists(file) ? file : null;
+
+            // Normalize path separators for Unix
+            file = file.Replace('\\', '/');
+
+            // Split path into components
+            string[] parts;
+            string resolved;
+
+            if (file.StartsWith("/"))
+            {
+                // Absolute path
+                parts = file.Substring(1).Split('/');
+                resolved = "/";
+            }
+            else
+            {
+                // Relative path
+                parts = file.Split('/');
+                resolved = "";
+            }
+
+            // Resolve each path component case-insensitively
+            foreach (var part in parts)
+            {
+                if (string.IsNullOrEmpty(part))
+                    continue;
+
+                var searchPath = string.IsNullOrEmpty(resolved) ? "." : resolved;
+
+                if (!Directory.Exists(searchPath))
+                    return null;
+
+                try
+                {
+                    var entries = Directory.GetFileSystemEntries(searchPath);
+                    var match = entries.FirstOrDefault(e =>
+                        Path.GetFileName(e).Equals(part, StringComparison.OrdinalIgnoreCase));
+
+                    if (match == null)
+                        return null;
+
+                    resolved = match;
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+
+            return File.Exists(resolved) ? resolved : null;
         }
     }
 }


### PR DESCRIPTION
Some updates I had to do to get Simitone to work on Linux. (Unfortunately, was not able to test on macOS)

<img width="1376" height="862" alt="image" src="https://github.com/user-attachments/assets/045a8823-931a-41ec-a536-b3944e1b39c8" />


I have done testing on Ubuntu (through WSL) and Linux Mint (through QEMU)

Currently have this implemented in Simitone on the `unix-support` branch. If this is merged, I'll update this branch to point at the new commit in upstream FreeSO instead of my own.
https://github.com/alexjyong/Simitone/tree/unix-support