### PR TITLE
Free will toggle support

### DIFF
--- a/TSOClient/FSO.UI/GlobalSettings.cs
+++ b/TSOClient/FSO.UI/GlobalSettings.cs
@@ -120,6 +120,7 @@ namespace FSO.Client
 
             { "ArchiveServerGUID", "" },
             { "ArchiveClientGUID", "" },
+            { "TS1FreeWill", "true" },
         };
 
         public override Dictionary<string, string> DefaultValues
@@ -195,6 +196,8 @@ namespace FSO.Client
 
         public string ArchiveServerGUID { get; set; }
         public string ArchiveClientGUID { get; set; }
+
+        public bool TS1FreeWill { get; set; }
 
         public static int TARGET_COMPAT_STATE = 2;
     }

--- a/TSOClient/tso.simantics/Primitives/VMFindBestAction.cs
+++ b/TSOClient/tso.simantics/Primitives/VMFindBestAction.cs
@@ -98,12 +98,22 @@ namespace FSO.SimAntics.Primitives
                 return VMPrimitiveExitCode.GOTO_TRUE;
             }
 
+            var caller = (VMAvatar)context.Caller;
+
+            // Check if free will is disabled for player family Sims
+            // Visitors (PersonType == 1) and pets should still have autonomy
+            var visitor = (caller.GetPersonData(VMPersonDataVariable.PersonType) == 1);
+            if (!VM.FreeWillEnabled && !visitor && !caller.IsPet)
+            {
+                // Free will is disabled and this is a player family Sim (not visitor, not pet)
+                // Return false to indicate no autonomous action was chosen
+                return VMPrimitiveExitCode.GOTO_FALSE;
+            }
+
             var ents = new List<VMEntity>(context.VM.Context.ObjectQueries.WithAutonomy);
             var processed = new HashSet<short>();
-            var caller = (VMAvatar)context.Caller;
             var pos1 = caller.Position;
 
-            var visitor = (caller.GetPersonData(VMPersonDataVariable.PersonType) == 1);
             var child = (caller.IsChild && context.VM.TS1);
             var attenTable = visitor ? TTAB.VisitorAttenuationValues : TTAB.AttenuationValues;
             var global = Content.Content.Get().WorldObjectGlobals;

--- a/TSOClient/tso.simantics/VM.cs
+++ b/TSOClient/tso.simantics/VM.cs
@@ -66,6 +66,12 @@ namespace FSO.SimAntics
         //we can assume one application won't be running TS1 and TSO at the same time.
         public bool Aborting = false;
 
+        /// <summary>
+        /// Global toggle for free will (autonomy). When disabled, player family Sims will not
+        /// autonomously choose actions. Visitors and pets still have free will.
+        /// </summary>
+        public static bool FreeWillEnabled = true;
+
         private const long TickInterval = 33 * TimeSpan.TicksPerMillisecond;
         public byte[][] HollowAdj;
 


### PR DESCRIPTION
This adds support for a Free Will Toggle button in Simitone:
(currently active here: https://github.com/alexjyong/Simitone/tree/free-will-toggle)

This code allows the UI have a button in options to turn on Free Will within the game.

<img width="1919" height="1019" alt="image" src="https://github.com/user-attachments/assets/530eb8c2-c027-42b4-9125-b4593657d205" />

<img width="1913" height="984" alt="image" src="https://github.com/user-attachments/assets/4cb4027a-47df-456b-81f8-2f9839ffb49c" />

