### PR TITLE
Fixed an issue where placing floor tiles would crash the game

### DIFF
--- a/TSOClient/tso.simantics/VMArchitecture.cs
+++ b/TSOClient/tso.simantics/VMArchitecture.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -495,7 +495,7 @@ namespace FSO.SimAntics
                 var com = commands[i];
                 var avaEnt = Context.VM.Entities.FirstOrDefault(x => x.PersistID == com.CallerUID);
                 if ((avaEnt == null || avaEnt is VMGameObject) && !transient && !Context.VM.TS1) return 0; //we need an avatar to run a command from net
-                var avatar = (transient)? null : (VMAvatar)avaEnt;
+                var avatar = (transient || !(avaEnt is VMAvatar)) ? null : (VMAvatar)avaEnt;
                 lastAvatar = avatar;
                 var styleInd = -1;
                 var walls = Content.Content.Get().WorldWalls;

--- a/TSOClient/tso.simantics/VMArchitecture.cs
+++ b/TSOClient/tso.simantics/VMArchitecture.cs
@@ -495,7 +495,7 @@ namespace FSO.SimAntics
                 var com = commands[i];
                 var avaEnt = Context.VM.Entities.FirstOrDefault(x => x.PersistID == com.CallerUID);
                 if ((avaEnt == null || avaEnt is VMGameObject) && !transient && !Context.VM.TS1) return 0; //we need an avatar to run a command from net
-                var avatar = (transient || !(avaEnt is VMAvatar)) ? null : (VMAvatar)avaEnt;
+                var avatar = (transient || Context.VM.TS1) ? null : (VMAvatar)avaEnt;
                 lastAvatar = avatar;
                 var styleInd = -1;
                 var walls = Content.Content.Get().WorldWalls;


### PR DESCRIPTION
Within VMArchitecture, Line 497 had a guard that skips if avaEnt is VMGameObject, but only when !Context.VM.TS1. Since   Simitone is always in TS1 mode, the guard is bypassed, and line 498 then tries to cast a VMGameObject to VMAvatar and crashes.

The result.....
<img width="1278" height="994" alt="image" src="https://github.com/user-attachments/assets/dacd1c6c-bf4b-449b-bb55-3609b8881a06" />

This PR fixes that, and lets players put in floor tiles without issue.