### PR TITLE
Fix freezed lot in Simitone

### DIFF
--- a/TSOClient/tso.simantics/NetPlay/VMNetDriver.cs
+++ b/TSOClient/tso.simantics/NetPlay/VMNetDriver.cs
@@ -87,7 +87,7 @@ namespace FSO.SimAntics.NetPlay
                 }
             }
 
-            if (tick.TickID < LastTick + 1) System.Console.WriteLine("Tick wrong (duplicate/early)! Got " + tick.TickID + ", Missed " + ((int)tick.TickID - (LastTick + 1)));
+            if (tick.TickID < LastTick) System.Console.WriteLine("Tick wrong (backwards)! Got " + tick.TickID + ", Missed " + ((int)tick.TickID - (LastTick + 1)));
             else if (doTick && vm.Context.Ready)
             {
                 if (tick.TickID > LastTick + 1) System.Console.WriteLine("Tick wrong (skipped)! Got " + tick.TickID + ", Missed " + ((int)tick.TickID - (LastTick + 1)));


### PR DESCRIPTION
While working on Simitone macOS/Linux support (Simitone.Unix), I noticed Sims on archive-experiment-temp had stopped moving entirely: the clock and lighting kept ticking, but avatars and objects sat frozen.

Commit 5497848 changed the check in VMNetDriver.InternalTick from

```csharp
  if (tick.TickID < LastTick)        // before
  if (tick.TickID < LastTick + 1)    // after
```

## What’s happening

The `Simitone.TS1GameScreen.BlueprintReset` method does this when starting a new game:

```csharp
vm.SpeedMultiplier = -1;
vm.Tick();
vm.SpeedMultiplier = 1;
```

Or we might need to update Simitone to adapt to the newer Tick system?